### PR TITLE
fix broken refdecoder after tfconfig upgrade

### DIFF
--- a/internal/refdecoder/decoder.go
+++ b/internal/refdecoder/decoder.go
@@ -45,14 +45,14 @@ func DecodeProviderReferences(m map[string]*hcl.File) (addrs.ProviderReferences,
 		}] = src
 	}
 
-	for name, aliases := range mod.ProviderAliases {
+	for _, cfg := range mod.ProviderConfigs {
 		src := refs[addrs.LocalProviderConfig{
-			LocalName: name,
+			LocalName: cfg.Name,
 		}]
-		for _, alias := range aliases {
+		if cfg.Alias != "" {
 			refs[addrs.LocalProviderConfig{
-				LocalName: name,
-				Alias:     alias,
+				LocalName: cfg.Name,
+				Alias:     cfg.Alias,
 			}] = src
 		}
 	}


### PR DESCRIPTION
It would help if I ran tests after bumping the dependency 😅 

This reflects changes discussed and implemented _after_ raising the initial PR https://github.com/hashicorp/terraform-config-inspect/pull/54