### PR TITLE
Upgrade tfjson to v0.7.0, remove duplicate case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/hcl-lang v0.0.0-20201110071249-4e412924f52b
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51
-	github.com/hashicorp/terraform-json v0.6.0
+	github.com/hashicorp/terraform-json v0.7.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
 	github.com/zclconf/go-cty v1.7.1-0.20201110003513-1338293a79a9
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51 h1:SEGO1vz/pFLfKy4QpABIMCe7wffmtsOiWO4yc1E87cU=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
-github.com/hashicorp/terraform-json v0.6.0 h1:nMTj4t9ysC7xJ72rvVsDqhUccvbUINrjhPqafeUeREk=
-github.com/hashicorp/terraform-json v0.6.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
+github.com/hashicorp/terraform-json v0.7.0 h1:DgkfLARKMQ/xmzVtSRX9Vz/fzPCL3vskHIgj6s+SQwQ=
+github.com/hashicorp/terraform-json v0.7.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/terraform-json"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-schema/internal/addrs"
 	"github.com/hashicorp/terraform-schema/internal/refdecoder"
 )
@@ -257,8 +257,6 @@ func markupContent(value string, kind tfjson.SchemaDescriptionKind) lang.MarkupC
 	case tfjson.SchemaDescriptionKindMarkdown:
 		return lang.Markdown(value)
 	case tfjson.SchemaDescriptionKindPlain:
-		return lang.PlainText(value)
-	case "plain": // discrepancy between terraform-json & Terraform core
 		return lang.PlainText(value)
 	}
 


### PR DESCRIPTION
v0.7.0 of terraform-json corrects the case discrepancy between core. Upcoming work in the language server requires this version of tfjson