### PR TITLE
Add documentation links to provider schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.3.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-version v1.2.0
-	github.com/hashicorp/hcl-lang v0.0.0-20201110071249-4e412924f52b
+	github.com/hashicorp/hcl-lang v0.0.0-20210213170001-bd00c3f68680
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51
 	github.com/hashicorp/terraform-json v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+d
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl-lang v0.0.0-20201110071249-4e412924f52b h1:EjnMRaTQlomBMNRQfyWoLEg9IdqxeN1R2mb3ZZetCBs=
-github.com/hashicorp/hcl-lang v0.0.0-20201110071249-4e412924f52b/go.mod h1:vd3BPEDWrYMAgAnB0MRlBdZknrpUXf8Jk2PNaHIbwhg=
+github.com/hashicorp/hcl-lang v0.0.0-20210213170001-bd00c3f68680 h1:QjPFluG2uGJCBKIp5sEFx+UZ98QnuxmVsnLIuHz8a2Y=
+github.com/hashicorp/hcl-lang v0.0.0-20210213170001-bd00c3f68680/go.mod h1:TZ5tpvmgJSHfmIndN4WP9SpZvyWK8tHPBY8LDRyU+pI=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.6.0 h1:3krZOfGY6SziUXa6H9PJU6TyohHn7I+ARYnhbeNBz+o=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -22,11 +22,19 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
 					Detail:     "hashicorp/null",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/hashicorp/null/latest/docs",
+						Tooltip: "hashicorp/null Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"random"}]}`: {
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
 					Detail:     "hashicorp/random",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/hashicorp/random/latest/docs",
+						Tooltip: "hashicorp/random Documentation",
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform"}]}`: {
 					Blocks:     map[string]*schema.BlockSchema{},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -20,6 +20,10 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
 				`{"labels":[{"index":0,"value":"grafana"}]}`: {
 					Detail: "grafana/grafana",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/grafana/grafana/latest/docs",
+						Tooltip: "grafana/grafana Documentation",
+					},
 					Blocks: map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{
 						"auth": {
@@ -41,12 +45,20 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					},
 				},
 				`{"labels":[{"index":0,"value":"null"}]}`: {
-					Detail:     "hashicorp/null",
+					Detail: "hashicorp/null",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/hashicorp/null/latest/docs",
+						Tooltip: "hashicorp/null Documentation",
+					},
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
 				},
 				`{"labels":[{"index":0,"value":"random"}]}`: {
-					Detail:     "hashicorp/random",
+					Detail: "hashicorp/random",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/hashicorp/random/latest/docs",
+						Tooltip: "hashicorp/random Documentation",
+					},
 					Blocks:     map[string]*schema.BlockSchema{},
 					Attributes: map[string]*schema.AttributeSchema{},
 				},


### PR DESCRIPTION
Depends on https://github.com/hashicorp/hcl-lang/pull/8

Currently limited to just provider docs as deep links to resources and data sources currently aren't easily predictable.