### PR TITLE
Return core schema if provider refs can't be decoded

### DIFF
--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -81,15 +81,15 @@ func (m *SchemaMerger) MergeWithJsonProviderSchemas(ps *tfjson.ProviderSchemas) 
 		mergedSchema.Blocks["data"].DependentBody = make(map[schema.SchemaKey]*schema.BodySchema)
 	}
 
-	refs, err := refdecoder.DecodeProviderReferences(m.parsedFiles)
-	if err != nil {
-		return m.coreSchema, err
+	refs, diags := refdecoder.DecodeProviderReferences(m.parsedFiles)
+	if diags.HasErrors() && len(refs) == 0 {
+		return m.coreSchema, nil
 	}
 
 	for sourceString, provider := range ps.Schemas {
 		srcAddr, err := addrs.ParseProviderSourceString(sourceString)
 		if err != nil {
-			return m.coreSchema, err
+			return m.coreSchema, nil
 		}
 
 		localRefs := refs.LocalNamesByAddr(srcAddr)


### PR DESCRIPTION
In cases where provider references cannot be decoded successfully, such as

```hcl
terraform {
  required_providers {
    newprovider = 
    aws = {
      source  = "hashicorp/aws"
      version = "~> 3.2"
    }
  }
}
```
or when the source string cannot be parsed, such as

```hcl
terraform {
  required_providers {
    aws = {
      source  = "invalidsource"
      version = "~> 3.2"
    }
  }
}
```

prior to this patch we would error out, which then causes all LS features relying on a schema to fail unnecessarily when they could still take advantage of the core schema - e.g. provide completion or hover for blocks and attributes which do not depend on provider schema.