### PR TITLE
ci: Enable codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,5 @@
+comment: false
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
This enables [codecov](https://about.codecov.io/) integration in the most minimal way possible. In particular it suppresses the PR comments and status, [such as these](https://github.com/hashicorp/hcl-lang/pull/9#issuecomment-779693393). Personally I don't find them as useful due to the fact that they can't be configured in more meaningful way - to avoid the noise on low-impact PRs, such as docs updates.

That said I do find codecov in itself useful when working on bigger PRs which refactor or introduce a lot of LOC - at which point I would just go straight to codecov.io and review the coverage impact of that particular PR there.