### PR TITLE
Reflect v0.15 configuration_aliases in provider referencing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcl-lang v0.0.0-20210317074414-9bb6847208c3
 	github.com/hashicorp/hcl/v2 v2.9.1
-	github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51
+	github.com/hashicorp/terraform-config-inspect v0.0.0-20210318070130-9a80970d6b34
 	github.com/hashicorp/terraform-json v0.9.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/hashicorp/hcl-lang v0.0.0-20210317074414-9bb6847208c3/go.mod h1:ZGuDQ
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.9.1 h1:eOy4gREY0/ZQHNItlfuEZqtcQbXIxzojlP301hDpnac=
 github.com/hashicorp/hcl/v2 v2.9.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
-github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51 h1:SEGO1vz/pFLfKy4QpABIMCe7wffmtsOiWO4yc1E87cU=
-github.com/hashicorp/terraform-config-inspect v0.0.0-20201102131242-0c45ba392e51/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20210318070130-9a80970d6b34 h1:y4kOB9aYVSsJWVqewwUZmHxPSNjkDbOeW7eb9yFIc3Q=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20210318070130-9a80970d6b34/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
 github.com/hashicorp/terraform-json v0.9.0 h1:WE7+Wt93W93feOiCligElSyS0tlDzwZUtJuDGIBr8zg=
 github.com/hashicorp/terraform-json v0.9.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/internal/refdecoder/decoder.go
+++ b/internal/refdecoder/decoder.go
@@ -43,6 +43,13 @@ func DecodeProviderReferences(m map[string]*hcl.File) (addrs.ProviderReferences,
 		refs[addrs.LocalProviderConfig{
 			LocalName: name,
 		}] = src
+
+		for _, alias := range req.ConfigurationAliases {
+			refs[addrs.LocalProviderConfig{
+				LocalName: alias.Name,
+				Alias:     alias.Alias,
+			}] = src
+		}
 	}
 
 	for _, cfg := range mod.ProviderConfigs {

--- a/internal/refdecoder/decoder_test.go
+++ b/internal/refdecoder/decoder_test.go
@@ -140,6 +140,37 @@ data "mycloud_instance" "foo" {
 				},
 			},
 		},
+		{
+			"configuration aliases",
+			`
+terraform {
+  required_providers {
+    xyz = {
+      source                = "grafana/grafana"
+      version               = "1.9.0"
+      configuration_aliases = [xyz.blah]
+    }
+  }
+}
+`,
+			addrs.ProviderReferences{
+				addrs.LocalProviderConfig{
+					LocalName: "xyz",
+				}: addrs.Provider{
+					Hostname:  addrs.DefaultRegistryHost,
+					Namespace: "grafana",
+					Type:      "grafana",
+				},
+				addrs.LocalProviderConfig{
+					LocalName: "xyz",
+					Alias:     "blah",
+				}: addrs.Provider{
+					Hostname:  addrs.DefaultRegistryHost,
+					Namespace: "grafana",
+					Type:      "grafana",
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
~Depends on https://github.com/hashicorp/terraform-config-inspect/pull/60~

--- 

This reflects changes introduced in https://github.com/hashicorp/terraform/pull/27739 where provider aliases can be declared via `configuration_aliases` inside the `required_providers` block entry.