### PR TITLE
Support attribute nested type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210317074414-9bb6847208c3
+	github.com/hashicorp/hcl-lang v0.0.0-20210408074632-f554ec565695
 	github.com/hashicorp/hcl/v2 v2.9.1
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20210318070130-9a80970d6b34
 	github.com/hashicorp/terraform-json v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+DbLISwf2B8WXEolNRA8BGCwI9jws=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl-lang v0.0.0-20210317074414-9bb6847208c3 h1:s33G8woMGjgqckJnOXbDqRi42kNfPs0+I5TmqRU5Xts=
-github.com/hashicorp/hcl-lang v0.0.0-20210317074414-9bb6847208c3/go.mod h1:ZGuDQ7IWG2eFZZJC4pBZFnbH8afJ8gyOPmlHt5lJZK0=
+github.com/hashicorp/hcl-lang v0.0.0-20210408074632-f554ec565695 h1:24eguy8t3dSR/yFO66QQp4PxczmiZeAhF2Mgj0ZGj1s=
+github.com/hashicorp/hcl-lang v0.0.0-20210408074632-f554ec565695/go.mod h1:ZGuDQ7IWG2eFZZJC4pBZFnbH8afJ8gyOPmlHt5lJZK0=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.9.1 h1:eOy4gREY0/ZQHNItlfuEZqtcQbXIxzojlP301hDpnac=
 github.com/hashicorp/hcl/v2 v2.9.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=

--- a/internal/schema/0.12/terraform_block.go
+++ b/internal/schema/0.12/terraform_block.go
@@ -72,7 +72,7 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 				Expr: schema.ExprConstraints{
 					schema.ObjectExpr{
 						Attributes: schema.ObjectExprAttributes{
-							"version": schema.ObjectAttribute{
+							"version": &schema.AttributeSchema{
 								Expr: schema.LiteralTypeOnly(cty.String),
 								Description: lang.Markdown("Version constraint specifying which subset of " +
 									"available provider versions the module is compatible with, e.g. `~> 1.0`"),

--- a/internal/schema/0.13/terraform_block.go
+++ b/internal/schema/0.13/terraform_block.go
@@ -56,12 +56,12 @@ var terraformBlockSchema = &schema.BlockSchema{
 						Expr: schema.ExprConstraints{
 							schema.ObjectExpr{
 								Attributes: schema.ObjectExprAttributes{
-									"source": schema.ObjectAttribute{
+									"source": &schema.AttributeSchema{
 										Expr: schema.LiteralTypeOnly(cty.String),
 										Description: lang.Markdown("The global source address for the provider " +
 											"you intend to use, such as `hashicorp/aws`"),
 									},
-									"version": schema.ObjectAttribute{
+									"version": &schema.AttributeSchema{
 										Expr: schema.LiteralTypeOnly(cty.String),
 										Description: lang.Markdown("Version constraint specifying which subset of " +
 											"available provider versions the module is compatible with, e.g. `~> 1.0`"),

--- a/internal/schema/0.14/terraform.go
+++ b/internal/schema/0.14/terraform.go
@@ -68,12 +68,12 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 							Expr: schema.ExprConstraints{
 								schema.ObjectExpr{
 									Attributes: schema.ObjectExprAttributes{
-										"source": schema.ObjectAttribute{
+										"source": &schema.AttributeSchema{
 											Expr: schema.LiteralTypeOnly(cty.String),
 											Description: lang.Markdown("The global source address for the provider " +
 												"you intend to use, such as `hashicorp/aws`"),
 										},
-										"version": schema.ObjectAttribute{
+										"version": &schema.AttributeSchema{
 											Expr: schema.LiteralTypeOnly(cty.String),
 											Description: lang.Markdown("Version constraint specifying which subset of " +
 												"available provider versions the module is compatible with, e.g. `~> 1.0`"),

--- a/internal/schema/0.15/terraform.go
+++ b/internal/schema/0.15/terraform.go
@@ -13,17 +13,17 @@ func patchTerraformBlockSchema(bs *schema.BlockSchema, v *version.Version) *sche
 			Expr: schema.ExprConstraints{
 				schema.ObjectExpr{
 					Attributes: schema.ObjectExprAttributes{
-						"source": schema.ObjectAttribute{
+						"source": &schema.AttributeSchema{
 							Expr: schema.LiteralTypeOnly(cty.String),
 							Description: lang.Markdown("The global source address for the provider " +
 								"you intend to use, such as `hashicorp/aws`"),
 						},
-						"version": schema.ObjectAttribute{
+						"version": &schema.AttributeSchema{
 							Expr: schema.LiteralTypeOnly(cty.String),
 							Description: lang.Markdown("Version constraint specifying which subset of " +
 								"available provider versions the module is compatible with, e.g. `~> 1.0`"),
 						},
-						"configuration_aliases": schema.ObjectAttribute{
+						"configuration_aliases": &schema.AttributeSchema{
 							Expr: schema.ExprConstraints{
 								schema.TupleConsExpr{
 									Name: "set of aliases",

--- a/schema/schema_merge_v015_test.go
+++ b/schema/schema_merge_v015_test.go
@@ -1,0 +1,418 @@
+package schema
+
+import (
+	//"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var expectedMergedSchema_v015 = &schema.BodySchema{
+	Blocks: map[string]*schema.BlockSchema{
+		"data": {
+			Labels: []*schema.LabelSchema{
+				{Name: "type"},
+				{Name: "name"},
+			},
+			Body: &schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"count": {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
+				},
+			},
+			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+				`{"labels":[{"index":0,"value":"hashicup_test"}],"attrs":[{"name":"provider","expr":{"addr":"hashicup"}}]}`: {
+					Blocks: map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {
+							IsRequired: true,
+							Expr: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+							},
+						},
+						"config1": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.ObjectExpr{
+									Attributes: schema.ObjectExprAttributes{
+										"first": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.LiteralTypeExpr{Type: cty.String},
+											},
+										},
+										"second": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.LiteralTypeExpr{Type: cty.Number},
+											},
+										},
+										"third": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.ObjectExpr{
+													Attributes: schema.ObjectExprAttributes{
+														"nested": {
+															IsOptional: true,
+															Expr: schema.ExprConstraints{
+																schema.LiteralTypeExpr{Type: cty.String},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"config2": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.ListExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 2,
+									MaxItems: 3,
+								},
+							},
+						},
+						"config3": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.SetExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 1,
+									MaxItems: 5,
+								},
+							},
+						},
+						"config4": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.MapExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 9,
+									MaxItems: 10,
+								},
+							},
+						},
+						"workspace": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+							},
+						},
+					},
+					Detail: "hashicorp/hashicup",
+				},
+				`{"labels":[{"index":0,"value":"hashicup_test"}]}`: {
+					Blocks: map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {
+							IsRequired: true,
+							Expr: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+							},
+						},
+						"config1": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.ObjectExpr{
+									Attributes: schema.ObjectExprAttributes{
+										"first": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.LiteralTypeExpr{Type: cty.String},
+											},
+										},
+										"second": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.LiteralTypeExpr{Type: cty.Number},
+											},
+										},
+										"third": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.ObjectExpr{
+													Attributes: schema.ObjectExprAttributes{
+														"nested": {
+															IsOptional: true,
+															Expr: schema.ExprConstraints{
+																schema.LiteralTypeExpr{Type: cty.String},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"config2": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.ListExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 2,
+									MaxItems: 3,
+								},
+							},
+						},
+						"config3": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.SetExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 1,
+									MaxItems: 5,
+								},
+							},
+						},
+						"config4": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.MapExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 9,
+									MaxItems: 10,
+								},
+							},
+						},
+						"workspace": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+							},
+						},
+					},
+					Detail: "hashicorp/hashicup",
+				},
+			},
+		},
+		"provider": {
+			Labels: []*schema.LabelSchema{
+				{Name: "name"},
+			},
+			Body: &schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"alias": {Expr: schema.LiteralTypeOnly(cty.String), IsOptional: true},
+				},
+			},
+			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+				`{"labels":[{"index":0,"value":"hashicup"}]}`: {
+					Blocks:     map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{},
+					Detail:     "hashicorp/hashicup",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/hashicorp/hashicup/latest/docs",
+						Tooltip: "hashicorp/hashicup Documentation",
+					},
+				},
+			},
+		},
+		"resource": {
+			Labels: []*schema.LabelSchema{
+				{Name: "type"},
+				{Name: "name"},
+			},
+			Body: &schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"count": {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
+				},
+			},
+			DependentBody: map[schema.SchemaKey]*schema.BodySchema{},
+		},
+	},
+}

--- a/schema/testdata/provider-schemas-0.15.json
+++ b/schema/testdata/provider-schemas-0.15.json
@@ -1,0 +1,161 @@
+{
+    "format_version": "0.1",
+    "provider_schemas": {
+        "registry.terraform.io/hashicorp/hashicup": {
+            "data_source_schemas": {
+                "hashicup_test": {
+                    "version": 0,
+                    "block": {
+                        "attributes": {
+                            "backend": {
+                                "type": "string",
+                                "description_kind": "plain",
+                                "required": true
+                            },
+                            "config1": {
+                                "nested_type": {
+                                    "attributes": {
+                                        "first": {
+                                            "type": "string",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "second": {
+                                            "type": "number",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "third": {
+                                            "nested_type": {
+                                                "attributes": {
+                                                    "nested": {
+                                                        "type": "string",
+                                                        "optional": true
+                                                    }
+                                                },
+                                                "nesting_mode": "single"
+                                            },
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        }
+                                    },
+                                    "nesting_mode": "single"
+                                },
+                                "description_kind": "plain",
+                                "optional": true
+                            },
+                            "config2": {
+                                "nested_type": {
+                                    "attributes": {
+                                        "first": {
+                                            "type": "string",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "second": {
+                                            "type": "number",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "third": {
+                                            "nested_type": {
+                                                "attributes": {
+                                                    "nested": {
+                                                        "type": "string",
+                                                        "optional": true
+                                                    }
+                                                },
+                                                "nesting_mode": "single"
+                                            },
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        }
+                                    },
+                                    "nesting_mode": "list",
+                                    "min_items": 2,
+                                    "max_items": 3
+                                },
+                                "description_kind": "plain",
+                                "optional": true
+                            },
+                            "config3": {
+                                "nested_type": {
+                                    "attributes": {
+                                        "first": {
+                                            "type": "string",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "second": {
+                                            "type": "number",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "third": {
+                                            "nested_type": {
+                                                "attributes": {
+                                                    "nested": {
+                                                        "type": "string",
+                                                        "optional": true
+                                                    }
+                                                },
+                                                "nesting_mode": "single"
+                                            },
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        }
+                                    },
+                                    "nesting_mode": "set",
+                                    "min_items": 1,
+                                    "max_items": 5
+                                },
+                                "description_kind": "plain",
+                                "optional": true
+                            },
+                            "config4": {
+                                "nested_type": {
+                                    "attributes": {
+                                        "first": {
+                                            "type": "string",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "second": {
+                                            "type": "number",
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        },
+                                        "third": {
+                                            "nested_type": {
+                                                "attributes": {
+                                                    "nested": {
+                                                        "type": "string",
+                                                        "optional": true
+                                                    }
+                                                },
+                                                "nesting_mode": "single"
+                                            },
+                                            "description_kind": "plain",
+                                            "optional": true
+                                        }
+                                    },
+                                    "nesting_mode": "map",
+                                    "min_items": 9,
+                                    "max_items": 10
+                                },
+                                "description_kind": "plain",
+                                "optional": true
+                            },
+                            "workspace": {
+                                "type": "string",
+                                "description_kind": "plain",
+                                "optional": true
+                            }
+                        },
+                        "description_kind": "plain"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/testdata/test-config-0.15.tf
+++ b/schema/testdata/test-config-0.15.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    hashicup = {
+      source  = "hashicorp/hashicup"
+      version = "0.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/hashicorp/hcl-lang/pull/28

--- 

This aims to support "nested attribute type" introduced as part of Terraform 0.15, support for which was added to terraform-json in hashicorp/terraform-json#28