### PR TITLE
SchemaMerger: Copy core schema before merging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-json v0.10.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
+	github.com/mitchellh/copystructure v1.1.2
 	github.com/zclconf/go-cty v1.8.1
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 )

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,12 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5 h1:shw+DWUaHIyW64Tv30ASCbC6QO6fLy+M5SJb5pJVEI4=
 github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5/go.mod h1:nHPoxaBUc5CDAMIv0MNmn5PBjWbTs9BI/eh30/n0U6g=
+github.com/mitchellh/copystructure v1.1.2 h1:Th2TIvG1+6ma3e/0/bopBKohOTY7s4dA8V2q4EUcBJ0=
 github.com/mitchellh/copystructure v1.1.2/go.mod h1:EBArHfARyrSWO/+Wyr9zwEkc6XMFB9XyNgFNmRkZZU4=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/schema/copiers.go
+++ b/schema/copiers.go
@@ -1,0 +1,22 @@
+package schema
+
+import (
+	"reflect"
+
+	"github.com/mitchellh/copystructure"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Some types have private fields, so we declare custom copiers for them
+var copiers = map[reflect.Type]copystructure.CopierFunc{
+	reflect.TypeOf(cty.NilType): ctyTypeCopier,
+	reflect.TypeOf(cty.Value{}): ctyValueCopier,
+}
+
+func ctyTypeCopier(v interface{}) (interface{}, error) {
+	return v.(cty.Type), nil
+}
+
+func ctyValueCopier(v interface{}) (interface{}, error) {
+	return v.(cty.Value), nil
+}

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform-schema/module"
+	"github.com/mitchellh/copystructure"
 )
 
 type SchemaMerger struct {
@@ -44,7 +45,14 @@ func (m *SchemaMerger) SchemaForModule(meta *module.Meta) (*schema.BodySchema, e
 		return m.coreSchema, nil
 	}
 
-	mergedSchema := m.coreSchema
+	schemaCopy, err := copystructure.Config{
+		Copiers: copiers,
+	}.Copy(m.coreSchema)
+	if err != nil {
+		return m.coreSchema, err
+	}
+
+	mergedSchema := schemaCopy.(*schema.BodySchema)
 
 	if mergedSchema.Blocks["provider"].DependentBody == nil {
 		mergedSchema.Blocks["provider"].DependentBody = make(map[schema.SchemaKey]*schema.BodySchema)

--- a/schema/schema_merge_v015_aliased_test.go
+++ b/schema/schema_merge_v015_aliased_test.go
@@ -1,0 +1,237 @@
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var expectedMergedSchema_v015_aliased = &schema.BodySchema{
+	Blocks: map[string]*schema.BlockSchema{
+		"data": {
+			Labels: []*schema.LabelSchema{
+				{Name: "type"},
+				{Name: "name"},
+			},
+			Body: &schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"count": {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
+				},
+			},
+			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+				`{"labels":[{"index":0,"value":"hashicup_test"}],"attrs":[{"name":"provider","expr":{"addr":"hcc"}}]}`: {
+					Blocks: map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {
+							IsRequired: true,
+							Expr: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+							},
+						},
+						"config1": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.ObjectExpr{
+									Attributes: schema.ObjectExprAttributes{
+										"first": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.LiteralTypeExpr{Type: cty.String},
+											},
+										},
+										"second": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.LiteralTypeExpr{Type: cty.Number},
+											},
+										},
+										"third": {
+											IsOptional: true,
+											Expr: schema.ExprConstraints{
+												schema.ObjectExpr{
+													Attributes: schema.ObjectExprAttributes{
+														"nested": {
+															IsOptional: true,
+															Expr: schema.ExprConstraints{
+																schema.LiteralTypeExpr{Type: cty.String},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"config2": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.ListExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 2,
+									MaxItems: 3,
+								},
+							},
+						},
+						"config3": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.SetExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 1,
+									MaxItems: 5,
+								},
+							},
+						},
+						"config4": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.MapExpr{
+									Elem: schema.ExprConstraints{
+										schema.ObjectExpr{
+											Attributes: schema.ObjectExprAttributes{
+												"first": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.String},
+													},
+												},
+												"second": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.LiteralTypeExpr{Type: cty.Number},
+													},
+												},
+												"third": {
+													IsOptional: true,
+													Expr: schema.ExprConstraints{
+														schema.ObjectExpr{
+															Attributes: schema.ObjectExprAttributes{
+																"nested": {
+																	IsOptional: true,
+																	Expr: schema.ExprConstraints{
+																		schema.LiteralTypeExpr{Type: cty.String},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									MinItems: 9,
+									MaxItems: 10,
+								},
+							},
+						},
+						"workspace": {
+							IsOptional: true,
+							Expr: schema.ExprConstraints{
+								schema.LiteralTypeExpr{Type: cty.String},
+							},
+						},
+					},
+					Detail: "hashicorp/hashicup",
+				},
+			},
+		},
+		"provider": {
+			Labels: []*schema.LabelSchema{
+				{Name: "name"},
+			},
+			Body: &schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"alias": {Expr: schema.LiteralTypeOnly(cty.String), IsOptional: true},
+				},
+			},
+			DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+				`{"labels":[{"index":0,"value":"hcc"}]}`: {
+					Blocks:     map[string]*schema.BlockSchema{},
+					Attributes: map[string]*schema.AttributeSchema{},
+					Detail:     "hashicorp/hashicup",
+					DocsLink: &schema.DocsLink{
+						URL:     "https://registry.terraform.io/providers/hashicorp/hashicup/latest/docs",
+						Tooltip: "hashicorp/hashicup Documentation",
+					},
+				},
+			},
+		},
+		"resource": {
+			Labels: []*schema.LabelSchema{
+				{Name: "type"},
+				{Name: "name"},
+			},
+			Body: &schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{
+					"count": {Expr: schema.LiteralTypeOnly(cty.Number), IsOptional: true},
+				},
+			},
+			DependentBody: map[schema.SchemaKey]*schema.BodySchema{},
+		},
+	},
+}


### PR DESCRIPTION
As demonstrated by the test, prior to this patch if `SchemaMerger.SchemaForModule()` was called multiple times on the same instance, we'd keep mutating the same single copy of core schema, which then results in duplicate dependent keys in the map, which then in turn cause this awkward UX in LS:

![2021-04-20 12 35 19](https://user-images.githubusercontent.com/287584/115389440-02157a00-a1d5-11eb-90fd-b087efc2ba19.gif)
