### PR TITLE
schema: avoid creating links for legacy namespace

### DIFF
--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -214,6 +214,12 @@ func providerHasDocs(addr tfaddr.Provider) bool {
 		// but there aren't any for the built-in provider yet
 		return false
 	}
+	if addr.IsLegacy() {
+		// The Registry does know where legacy providers live
+		// but it doesn't provide stable (legacy) URLs
+		return false
+	}
+
 	if addr.Hostname != "registry.terraform.io" {
 		// docs URLs outside of the official Registry aren't standardized yet
 		return false


### PR DESCRIPTION
To my knowledge the Registry does not have a public URL that would accept the legacy `-` namespace and redirect user to the new one, unlike the API.

Therefore it is safer to just not create links at all in such case.
