### PR TITLE
Add `default` variable schema

### DIFF
--- a/internal/schema/0.12/variable_block.go
+++ b/internal/schema/0.12/variable_block.go
@@ -39,11 +39,6 @@ func variableBlockSchema(v *version.Version) *schema.BlockSchema {
 					IsOptional:  true,
 					Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
 				},
-				"default": {
-					Expr:        schema.ExprConstraints{},
-					IsOptional:  true,
-					Description: lang.Markdown("Default value to use when variable is not explicitly set"),
-				},
 			},
 			Blocks: make(map[string]*schema.BlockSchema, 0),
 		},

--- a/internal/schema/0.14/variable_block.go
+++ b/internal/schema/0.14/variable_block.go
@@ -38,11 +38,6 @@ var variableBlockSchema = &schema.BlockSchema{
 				IsOptional:  true,
 				Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
 			},
-			"default": {
-				Expr:        schema.ExprConstraints{},
-				IsOptional:  true,
-				Description: lang.Markdown("Default value to use when variable is not explicitly set"),
-			},
 			"sensitive": {
 				Expr:        schema.LiteralTypeOnly(cty.Bool),
 				IsOptional:  true,


### PR DESCRIPTION
To support completion/hover/highlighting for variable `default`.

As part of this change, the `default` attribute was removed from the
variable schema block so that it can be set by the decoder.

Related to hashicorp/terraform-ls#537