### PR TITLE
Add support for variable `type`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210603100913-81056fd9a6e0
+	github.com/hashicorp/hcl-lang v0.0.0-20210609120759-c626a5e211fc
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/terraform-json v0.11.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hcl-lang v0.0.0-20210603100913-81056fd9a6e0 h1:CmEDMGKu8J5E8Yk4lcYwS8tC/K2ybAQ4nStw8raIjVQ=
-github.com/hashicorp/hcl-lang v0.0.0-20210603100913-81056fd9a6e0/go.mod h1:uMsq6wV8ZXEH8qndov4tncXlHDYnZ8aHsGmS4T74e2o=
+github.com/hashicorp/hcl-lang v0.0.0-20210609120759-c626a5e211fc h1:Kuz00XoVdIcsZ4ak4xI1Tc/1waKqAISzgqgzWn0DE2Y=
+github.com/hashicorp/hcl-lang v0.0.0-20210609120759-c626a5e211fc/go.mod h1:uMsq6wV8ZXEH8qndov4tncXlHDYnZ8aHsGmS4T74e2o=
 github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/terraform-json v0.11.0 h1:4zDqqW2F3kOysORIaYKFGgWDYIRA3hwqx3XHeHkbBQ0=

--- a/internal/schema/0.12/variable_block.go
+++ b/internal/schema/0.12/variable_block.go
@@ -35,7 +35,7 @@ func variableBlockSchema(v *version.Version) *schema.BlockSchema {
 					Description: lang.Markdown("Description to document the purpose of the variable and what value is expected"),
 				},
 				"type": {
-					Expr:        schema.ExprConstraints{},
+					Expr:        schema.ExprConstraints{schema.TypeDeclarationExpr{}},
 					IsOptional:  true,
 					Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
 				},

--- a/internal/schema/0.14/variable_block.go
+++ b/internal/schema/0.14/variable_block.go
@@ -34,7 +34,7 @@ var variableBlockSchema = &schema.BlockSchema{
 				Description: lang.Markdown("Description to document the purpose of the variable and what value is expected"),
 			},
 			"type": {
-				Expr:        schema.ExprConstraints{},
+				Expr:        schema.ExprConstraints{schema.TypeDeclarationExpr{}},
 				IsOptional:  true,
 				Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
 			},


### PR DESCRIPTION
So that completion, hover and semantic-tokens work for variable `type`.

Related to hashicorp/terraform-ls#490