### PR TITLE
earlydecoder: Parse default value

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -646,8 +646,7 @@ variable "name" {
 				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
 				Variables: map[string]module.Variable{
 					"name": {
-						Type:       cty.DynamicPseudoType,
-						IsRequired: true,
+						Type: cty.DynamicPseudoType,
 					},
 				},
 			},
@@ -665,8 +664,7 @@ variable "name" {
 				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
 				Variables: map[string]module.Variable{
 					"name": {
-						Type:       cty.String,
-						IsRequired: true,
+						Type: cty.String,
 					},
 				},
 			},
@@ -686,7 +684,6 @@ variable "name" {
 					"name": {
 						Type:        cty.DynamicPseudoType,
 						Description: "description",
-						IsRequired:  true,
 					},
 				},
 			},
@@ -706,7 +703,6 @@ variable "name" {
 					"name": {
 						Type:        cty.DynamicPseudoType,
 						IsSensitive: true,
-						IsRequired:  true,
 					},
 				},
 			},
@@ -729,7 +725,6 @@ variable "name" {
 						Type:        cty.String,
 						Description: "description",
 						IsSensitive: true,
-						IsRequired:  true,
 					},
 				},
 			},
@@ -747,8 +742,8 @@ variable "name" {
 				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
 				Variables: map[string]module.Variable{
 					"name": {
-						Type:       cty.DynamicPseudoType,
-						IsRequired: false,
+						Type:         cty.DynamicPseudoType,
+						DefaultValue: cty.EmptyObjectVal,
 					},
 				},
 			},

--- a/module/variable.go
+++ b/module/variable.go
@@ -11,6 +11,8 @@ type Variable struct {
 	// In case the version it is before 0.14 sensitive will always be false
 	// that was actually the default value for prior versions
 	IsSensitive bool
-	// IsRequired represents whether the variable has undefined default value
-	IsRequired bool
+
+	// DefaultValue represents default value if one is defined
+	// and is decodable without errors, else cty.NilVal
+	DefaultValue cty.Value
 }

--- a/schema/variable_schema.go
+++ b/schema/variable_schema.go
@@ -4,20 +4,34 @@ import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/terraform-schema/module"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func SchemaForVariables(vars map[string]module.Variable) (*schema.BodySchema, error) {
 	varSchemas := make(map[string]*schema.AttributeSchema)
 
 	for name, v := range vars {
+		varType := v.Type
+		if (varType == cty.DynamicPseudoType || varType == cty.NilType) &&
+			v.DefaultValue != cty.NilVal {
+			// infer type from default value if one is not specified
+			// or when it's "any"
+			varType = v.DefaultValue.Type()
+		}
+
 		varSchemas[name] = &schema.AttributeSchema{
 			Description: lang.MarkupContent{
 				Value: v.Description,
 				Kind:  lang.PlainTextKind,
 			},
-			Expr:        schema.ExprConstraints{schema.LiteralTypeExpr{Type: v.Type}},
+			Expr:        schema.ExprConstraints{schema.LiteralTypeExpr{Type: varType}},
 			IsSensitive: v.IsSensitive,
-			IsRequired:  v.IsRequired,
+		}
+
+		if v.DefaultValue == cty.NilVal {
+			varSchemas[name].IsRequired = true
+		} else {
+			varSchemas[name].IsOptional = true
 		}
 	}
 

--- a/schema/variable_schema_test.go
+++ b/schema/variable_schema_test.go
@@ -26,51 +26,86 @@ func TestSchemaForVariables(t *testing.T) {
 		{
 			"one attribute schema",
 			map[string]module.Variable{
-				"name": module.Variable{
+				"name": {
 					Description: "name of the module",
 					Type:        cty.String,
 				},
 			},
 			&schema.BodySchema{Attributes: map[string]*schema.AttributeSchema{
-				"name": &schema.AttributeSchema{
+				"name": {
 					Description: lang.MarkupContent{
 						Value: "name of the module",
 						Kind:  lang.PlainTextKind,
 					},
-					Expr: schema.ExprConstraints{schema.LiteralTypeExpr{cty.String}},
+					IsRequired: true,
+					Expr:       schema.LiteralTypeOnly(cty.String),
 				},
 			}},
 		},
 		{
 			"two attribute schema",
 			map[string]module.Variable{
-				"name": module.Variable{
-					Description: "name of the module",
-					Type:        cty.String,
+				"name": {
+					Description:  "name of the module",
+					Type:         cty.String,
+					DefaultValue: cty.StringVal("default"),
 				},
-				"id": module.Variable{
+				"id": {
 					Description: "id of the module",
 					Type:        cty.Number,
 					IsSensitive: true,
-					IsRequired:  true,
 				},
 			},
 			&schema.BodySchema{Attributes: map[string]*schema.AttributeSchema{
-				"name": &schema.AttributeSchema{
+				"name": {
 					Description: lang.MarkupContent{
 						Value: "name of the module",
 						Kind:  lang.PlainTextKind,
 					},
-					Expr: schema.ExprConstraints{schema.LiteralTypeExpr{cty.String}},
+					IsOptional: true,
+					Expr:       schema.LiteralTypeOnly(cty.String),
 				},
-				"id": &schema.AttributeSchema{
+				"id": {
 					Description: lang.MarkupContent{
 						Value: "id of the module",
 						Kind:  lang.PlainTextKind,
 					},
-					Expr:        schema.ExprConstraints{schema.LiteralTypeExpr{cty.Number}},
+					Expr:        schema.LiteralTypeOnly(cty.Number),
 					IsSensitive: true,
 					IsRequired:  true,
+				},
+			}},
+		},
+		{
+			"attribute with type from default value",
+			map[string]module.Variable{
+				"name": {
+					Description:  "name of the module",
+					Type:         cty.DynamicPseudoType,
+					DefaultValue: cty.StringVal("default"),
+				},
+				"id": {
+					Description:  "id of the module",
+					Type:         cty.NilType,
+					DefaultValue: cty.NumberIntVal(42),
+				},
+			},
+			&schema.BodySchema{Attributes: map[string]*schema.AttributeSchema{
+				"name": {
+					Description: lang.MarkupContent{
+						Value: "name of the module",
+						Kind:  lang.PlainTextKind,
+					},
+					IsOptional: true,
+					Expr:       schema.LiteralTypeOnly(cty.String),
+				},
+				"id": {
+					Description: lang.MarkupContent{
+						Value: "id of the module",
+						Kind:  lang.PlainTextKind,
+					},
+					Expr:       schema.LiteralTypeOnly(cty.Number),
+					IsOptional: true,
 				},
 			}},
 		},


### PR DESCRIPTION
Firstly this patch changes the API of `earlydecoder` and makes it more tightly coupled with the configuration it's parsing and less concerned about making conclusions based on the parsed configuration - i.e. whether a variable is optional or required. That logic has moved to `SchemaForVariables` instead.

As per `SchemaForVariables` changes, this also enhances completion/hover/etc. data for tfvars for cases where a variable has unspecified type but known default, e.g.

```hcl
variable "example" {
  default = "known-string"
}
```
```hcl
variable "example" {
  type = any
  default = "known-string"
}
```
^ the completion/hover/etc. in both cases would consider that variable to be of type string.
