### PR TITLE
Reflect that some attributes are convertible to blocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605
+	github.com/hashicorp/hcl-lang v0.0.0-20210803155453-7c098e4940bc
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/terraform-json v0.12.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605 h1:558O3NRU7baTVlQNgui1NeHDORRFEgTsICpHmI+ubA0=
-github.com/hashicorp/hcl-lang v0.0.0-20210730145509-f403a86a1605/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
+github.com/hashicorp/hcl-lang v0.0.0-20210803155453-7c098e4940bc h1:c0EJ6tK81OTD609/r4fgjf/SUy9A4CSUDMQL3qnt8NY=
+github.com/hashicorp/hcl-lang v0.0.0-20210803155453-7c098e4940bc/go.mod h1:xzXU6Fn+TWVaZUFxV8CyAsObi2oMgSEFAmLvCx2ArzM=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/terraform-json v0.12.0 h1:8czPgEEWWPROStjkWPUnTQDXmpmZPlkQAwYYLETaTvw=

--- a/schema/convert_json_test.go
+++ b/schema/convert_json_test.go
@@ -1,83 +1,365 @@
 package schema
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
+	tfjson "github.com/hashicorp/terraform-json"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestProviderSchema_SetProviderVersion(t *testing.T) {
-	ps := &ProviderSchema{
-		Provider: &schema.BodySchema{},
+func TestProviderSchemaFromJson_empty(t *testing.T) {
+	jsonSchema := &tfjson.ProviderSchema{}
+	providerAddr := tfaddr.NewDefaultProvider("aws")
+
+	ps := ProviderSchemaFromJson(jsonSchema, providerAddr)
+	expectedPs := &ProviderSchema{
+		Resources:   map[string]*schema.BodySchema{},
+		DataSources: map[string]*schema.BodySchema{},
+	}
+
+	if diff := cmp.Diff(expectedPs, ps, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("provider schema mismatch: %s", diff)
+	}
+}
+
+func TestProviderSchemaFromJson_basic(t *testing.T) {
+	rawSchema := `{
+	"resource_schemas": {
+		"aws_security_group": {
+			"version": 1,
+			"block": {
+				"attributes": {
+					"textfield": {
+						"type": "string",
+						"description_kind": "plain",
+						"optional": true
+					},
+					"simple_list": {
+						"type": [
+							"list",
+							"string"
+						],
+						"description_kind": "plain",
+						"optional": true
+					},
+					"ingress": {
+						"type": [
+							"set",
+							[
+								"object",
+								{
+									"cidr_blocks": [
+										"list",
+										"string"
+									],
+									"description": "string",
+									"from_port": "number",
+									"self": "bool"
+								}
+							]
+						],
+						"description_kind": "plain",
+						"optional": true,
+						"computed": true
+					},
+					"egress": {
+						"type": [
+							"list",
+							[
+								"object",
+								{
+									"cidr_blocks": [
+										"list",
+										"string"
+									],
+									"description": "string",
+									"from_port": "number",
+									"self": "bool"
+								}
+							]
+						],
+						"description_kind": "plain",
+						"optional": true,
+						"computed": true
+					}
+				}
+			}
+		}
+	}
+}`
+	jsonSchema := &tfjson.ProviderSchema{}
+	err := json.Unmarshal([]byte(rawSchema), jsonSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerAddr := tfaddr.NewDefaultProvider("aws")
+
+	ps := ProviderSchemaFromJson(jsonSchema, providerAddr)
+	expectedPs := &ProviderSchema{
 		Resources: map[string]*schema.BodySchema{
-			"foo": {
+			"aws_security_group": {
 				Attributes: map[string]*schema.AttributeSchema{
-					"str": {
-						Expr:       schema.LiteralTypeOnly(cty.String),
+					"egress": {
 						IsOptional: true,
+						IsComputed: true,
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.List(cty.Object(map[string]cty.Type{
+								"cidr_blocks": cty.List(cty.String),
+								"description": cty.String,
+								"from_port":   cty.Number,
+								"self":        cty.Bool,
+							}))},
+							schema.LiteralTypeExpr{Type: cty.List(cty.Object(map[string]cty.Type{
+								"cidr_blocks": cty.List(cty.String),
+								"description": cty.String,
+								"from_port":   cty.Number,
+								"self":        cty.Bool,
+							}))},
+							schema.ListExpr{
+								Elem: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.Object(map[string]cty.Type{
+										"cidr_blocks": cty.List(cty.String),
+										"description": cty.String,
+										"from_port":   cty.Number,
+										"self":        cty.Bool,
+									})},
+									schema.LiteralTypeExpr{Type: cty.Object(map[string]cty.Type{
+										"cidr_blocks": cty.List(cty.String),
+										"description": cty.String,
+										"from_port":   cty.Number,
+										"self":        cty.Bool,
+									})},
+									schema.ObjectExpr{
+										Attributes: schema.ObjectExprAttributes{
+											"cidr_blocks": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.List(cty.String)},
+													schema.LiteralTypeExpr{Type: cty.List(cty.String)},
+													schema.ListExpr{
+														Elem: schema.ExprConstraints{
+															schema.TraversalExpr{OfType: cty.String},
+															schema.LiteralTypeExpr{Type: cty.String},
+														},
+													},
+												},
+											},
+											"description": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.String},
+													schema.LiteralTypeExpr{Type: cty.String},
+												},
+											},
+											"from_port": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.Number},
+													schema.LiteralTypeExpr{Type: cty.Number},
+												},
+											},
+											"self": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.Bool},
+													schema.LiteralTypeExpr{Type: cty.Bool},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"ingress": {
+						IsOptional: true,
+						IsComputed: true,
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.Set(cty.Object(map[string]cty.Type{
+								"cidr_blocks": cty.List(cty.String),
+								"description": cty.String,
+								"from_port":   cty.Number,
+								"self":        cty.Bool,
+							}))},
+							schema.LiteralTypeExpr{Type: cty.Set(cty.Object(map[string]cty.Type{
+								"cidr_blocks": cty.List(cty.String),
+								"description": cty.String,
+								"from_port":   cty.Number,
+								"self":        cty.Bool,
+							}))},
+							schema.SetExpr{
+								Elem: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.Object(map[string]cty.Type{
+										"cidr_blocks": cty.List(cty.String),
+										"description": cty.String,
+										"from_port":   cty.Number,
+										"self":        cty.Bool,
+									})},
+									schema.LiteralTypeExpr{Type: cty.Object(map[string]cty.Type{
+										"cidr_blocks": cty.List(cty.String),
+										"description": cty.String,
+										"from_port":   cty.Number,
+										"self":        cty.Bool,
+									})},
+									schema.ObjectExpr{
+										Attributes: schema.ObjectExprAttributes{
+											"cidr_blocks": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.List(cty.String)},
+													schema.LiteralTypeExpr{Type: cty.List(cty.String)},
+													schema.ListExpr{
+														Elem: schema.ExprConstraints{
+															schema.TraversalExpr{OfType: cty.String},
+															schema.LiteralTypeExpr{Type: cty.String},
+														},
+													},
+												},
+											},
+											"description": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.String},
+													schema.LiteralTypeExpr{Type: cty.String},
+												},
+											},
+											"from_port": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.Number},
+													schema.LiteralTypeExpr{Type: cty.Number},
+												},
+											},
+											"self": {
+												IsRequired: true,
+												Expr: schema.ExprConstraints{
+													schema.TraversalExpr{OfType: cty.Bool},
+													schema.LiteralTypeExpr{Type: cty.Bool},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"simple_list": {
+						IsOptional: true,
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.List(cty.String)},
+							schema.LiteralTypeExpr{Type: cty.List(cty.String)},
+							schema.ListExpr{
+								Elem: schema.ExprConstraints{
+									schema.TraversalExpr{OfType: cty.String},
+									schema.LiteralTypeExpr{Type: cty.String},
+								},
+							},
+						},
+					},
+					"textfield": {
+						IsOptional: true,
+						Expr: schema.ExprConstraints{
+							schema.TraversalExpr{OfType: cty.String},
+							schema.LiteralTypeExpr{Type: cty.String},
+						},
 					},
 				},
-			},
-		},
-		DataSources: map[string]*schema.BodySchema{
-			"bar": {
-				Attributes: map[string]*schema.AttributeSchema{
-					"num": {
-						Expr:       schema.LiteralTypeOnly(cty.Number),
-						IsOptional: true,
+				Blocks: map[string]*schema.BlockSchema{
+					"egress": {
+						Type: schema.BlockTypeList,
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"cidr_blocks": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.List(cty.String)},
+										schema.LiteralTypeExpr{Type: cty.List(cty.String)},
+										schema.ListExpr{
+											Elem: schema.ExprConstraints{
+												schema.TraversalExpr{OfType: cty.String},
+												schema.LiteralTypeExpr{Type: cty.String},
+											},
+										},
+									},
+								},
+								"description": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.String},
+										schema.LiteralTypeExpr{Type: cty.String},
+									},
+								},
+								"from_port": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.Number},
+										schema.LiteralTypeExpr{Type: cty.Number},
+									},
+								},
+								"self": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.Bool},
+										schema.LiteralTypeExpr{Type: cty.Bool},
+									},
+								},
+							},
+						},
+					},
+					"ingress": {
+						Type: schema.BlockTypeSet,
+						Body: &schema.BodySchema{
+							Attributes: map[string]*schema.AttributeSchema{
+								"cidr_blocks": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.List(cty.String)},
+										schema.LiteralTypeExpr{Type: cty.List(cty.String)},
+										schema.ListExpr{
+											Elem: schema.ExprConstraints{
+												schema.TraversalExpr{OfType: cty.String},
+												schema.LiteralTypeExpr{Type: cty.String},
+											},
+										},
+									},
+								},
+								"description": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.String},
+										schema.LiteralTypeExpr{Type: cty.String},
+									},
+								},
+								"from_port": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.Number},
+										schema.LiteralTypeExpr{Type: cty.Number},
+									},
+								},
+								"self": {
+									IsOptional: true,
+									Expr: schema.ExprConstraints{
+										schema.TraversalExpr{OfType: cty.Bool},
+										schema.LiteralTypeExpr{Type: cty.Bool},
+									},
+								},
+							},
+						},
 					},
 				},
+				Detail: "hashicorp/aws",
 			},
 		},
-	}
-	expectedSchema := &ProviderSchema{
-		Provider: &schema.BodySchema{
-			Detail:   "hashicorp/aws 1.2.5",
-			HoverURL: "https://registry.terraform.io/providers/hashicorp/aws/1.2.5/docs",
-			DocsLink: &schema.DocsLink{
-				URL:     "https://registry.terraform.io/providers/hashicorp/aws/1.2.5/docs",
-				Tooltip: "hashicorp/aws Documentation",
-			},
-		},
-		Resources: map[string]*schema.BodySchema{
-			"foo": {
-				Detail: "hashicorp/aws 1.2.5",
-				Attributes: map[string]*schema.AttributeSchema{
-					"str": {
-						Expr:       schema.LiteralTypeOnly(cty.String),
-						IsOptional: true,
-					},
-				},
-			},
-		},
-		DataSources: map[string]*schema.BodySchema{
-			"bar": {
-				Detail: "hashicorp/aws 1.2.5",
-				Attributes: map[string]*schema.AttributeSchema{
-					"num": {
-						Expr:       schema.LiteralTypeOnly(cty.Number),
-						IsOptional: true,
-					},
-				},
-			},
-		},
+		DataSources: map[string]*schema.BodySchema{},
 	}
 
-	pAddr := tfaddr.Provider{
-		Hostname:  tfaddr.DefaultRegistryHost,
-		Namespace: "hashicorp",
-		Type:      "aws",
-	}
-	pv := version.Must(version.NewVersion("1.2.5"))
-
-	ps.SetProviderVersion(pAddr, pv)
-
-	if diff := cmp.Diff(expectedSchema, ps, ctydebug.CmpOptions); diff != "" {
-		t.Fatalf("unexpected schema: %s", diff)
+	if diff := cmp.Diff(expectedPs, ps, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("provider schema mismatch: %s", diff)
 	}
 }

--- a/schema/provider_schema.go
+++ b/schema/provider_schema.go
@@ -1,0 +1,54 @@
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+type ProviderSchema struct {
+	Provider    *schema.BodySchema
+	Resources   map[string]*schema.BodySchema
+	DataSources map[string]*schema.BodySchema
+	Module      *schema.BodySchema
+}
+
+func (ps *ProviderSchema) Copy() *ProviderSchema {
+	if ps == nil {
+		return nil
+	}
+
+	newPs := &ProviderSchema{
+		Provider: ps.Provider.Copy(),
+	}
+
+	if ps.Resources != nil {
+		newPs.Resources = make(map[string]*schema.BodySchema, len(ps.Resources))
+		for name, rSchema := range ps.Resources {
+			newPs.Resources[name] = rSchema.Copy()
+		}
+	}
+
+	if ps.DataSources != nil {
+		newPs.DataSources = make(map[string]*schema.BodySchema, len(ps.DataSources))
+		for name, rSchema := range ps.DataSources {
+			newPs.DataSources[name] = rSchema.Copy()
+		}
+	}
+
+	return newPs
+}
+
+func (ps *ProviderSchema) SetProviderVersion(pAddr tfaddr.Provider, v *version.Version) {
+	if ps.Provider != nil {
+		ps.Provider.Detail = detailForSrcAddr(pAddr, v)
+		ps.Provider.HoverURL = urlForProvider(pAddr, v)
+		ps.Provider.DocsLink = docsLinkForProvider(pAddr, v)
+	}
+	for _, rSchema := range ps.Resources {
+		rSchema.Detail = detailForSrcAddr(pAddr, v)
+	}
+	for _, dsSchema := range ps.DataSources {
+		dsSchema.Detail = detailForSrcAddr(pAddr, v)
+	}
+}

--- a/schema/provider_schema_test.go
+++ b/schema/provider_schema_test.go
@@ -1,0 +1,83 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestProviderSchema_SetProviderVersion(t *testing.T) {
+	ps := &ProviderSchema{
+		Provider: &schema.BodySchema{},
+		Resources: map[string]*schema.BodySchema{
+			"foo": {
+				Attributes: map[string]*schema.AttributeSchema{
+					"str": {
+						Expr:       schema.LiteralTypeOnly(cty.String),
+						IsOptional: true,
+					},
+				},
+			},
+		},
+		DataSources: map[string]*schema.BodySchema{
+			"bar": {
+				Attributes: map[string]*schema.AttributeSchema{
+					"num": {
+						Expr:       schema.LiteralTypeOnly(cty.Number),
+						IsOptional: true,
+					},
+				},
+			},
+		},
+	}
+	expectedSchema := &ProviderSchema{
+		Provider: &schema.BodySchema{
+			Detail:   "hashicorp/aws 1.2.5",
+			HoverURL: "https://registry.terraform.io/providers/hashicorp/aws/1.2.5/docs",
+			DocsLink: &schema.DocsLink{
+				URL:     "https://registry.terraform.io/providers/hashicorp/aws/1.2.5/docs",
+				Tooltip: "hashicorp/aws Documentation",
+			},
+		},
+		Resources: map[string]*schema.BodySchema{
+			"foo": {
+				Detail: "hashicorp/aws 1.2.5",
+				Attributes: map[string]*schema.AttributeSchema{
+					"str": {
+						Expr:       schema.LiteralTypeOnly(cty.String),
+						IsOptional: true,
+					},
+				},
+			},
+		},
+		DataSources: map[string]*schema.BodySchema{
+			"bar": {
+				Detail: "hashicorp/aws 1.2.5",
+				Attributes: map[string]*schema.AttributeSchema{
+					"num": {
+						Expr:       schema.LiteralTypeOnly(cty.Number),
+						IsOptional: true,
+					},
+				},
+			},
+		},
+	}
+
+	pAddr := tfaddr.Provider{
+		Hostname:  tfaddr.DefaultRegistryHost,
+		Namespace: "hashicorp",
+		Type:      "aws",
+	}
+	pv := version.Must(version.NewVersion("1.2.5"))
+
+	ps.SetProviderVersion(pAddr, pv)
+
+	if diff := cmp.Diff(expectedSchema, ps, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("unexpected schema: %s", diff)
+	}
+}

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -19,42 +19,9 @@ type SchemaMerger struct {
 	moduleReader     ModuleReader
 }
 
-type ProviderSchema struct {
-	Provider    *schema.BodySchema
-	Resources   map[string]*schema.BodySchema
-	DataSources map[string]*schema.BodySchema
-	Module      *schema.BodySchema
-}
-
 type ModuleReader interface {
 	ModuleCalls(modPath string) ([]module.ModuleCall, error)
 	ModuleMeta(modPath string) (*module.Meta, error)
-}
-
-func (ps *ProviderSchema) Copy() *ProviderSchema {
-	if ps == nil {
-		return nil
-	}
-
-	newPs := &ProviderSchema{
-		Provider: ps.Provider.Copy(),
-	}
-
-	if ps.Resources != nil {
-		newPs.Resources = make(map[string]*schema.BodySchema, len(ps.Resources))
-		for name, rSchema := range ps.Resources {
-			newPs.Resources[name] = rSchema.Copy()
-		}
-	}
-
-	if ps.DataSources != nil {
-		newPs.DataSources = make(map[string]*schema.BodySchema, len(ps.DataSources))
-		for name, rSchema := range ps.DataSources {
-			newPs.DataSources[name] = rSchema.Copy()
-		}
-	}
-
-	return newPs
 }
 
 type SchemaReader interface {


### PR DESCRIPTION
This reflects some built-in logic that the schema convertor previously wasn't aware of where certain attributes of `list(object)` or `set(object)` type are treated as blocks, for backwards compatible reasons.

This logic is mostly contained within https://github.com/hashicorp/terraform/blob/v1.0.3/internal/lang/blocktoattr/schema.go and the SDK effectively exposes this via [`SchemaConfigMode`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema#SchemaConfigMode) but this is never directly exposed over the gRPC protocol. Instead core just "makes a guess" based on the assumption that historically lists and sets with elements of non-primitive types could only be built as blocks and this still holds true today in the linked SDK.

The AWS provider for example uses it in `aws_security_group`:
https://github.com/hashicorp/terraform-provider-aws/blob/236172f78e8ce7813ab26fe1338a4971e4594d33/aws/resource_aws_security_group.go#L85

This aims to address a bug reported in https://github.com/hashicorp/terraform-ls/issues/600