### PR TITLE
ci: Remove codecov

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,5 +1,0 @@
-comment: false
-coverage:
-  status:
-    project: off
-    patch: off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,4 @@ jobs:
         run: go run github.com/mh-cbon/go-fmt-fail ./...
       -
         name: Run tests
-        run: go test -v -coverprofile="coverage.txt" -covermode=atomic ./...
-      - 
-        name: Upload code coverage report
-        uses: codecov/codecov-action@v1
-        with:
-          file: coverage.txt
-          env_vars: "GOOS,GOARCH"
+        run: go test -v -covermode=atomic ./...


### PR DESCRIPTION
Codecov was disabled org-wide as a part of responding to the security incident [HCSEC-2021-12](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512).

This is a follow-up PR to remove the integration which no longer works due to that.
