### PR TITLE
Allow non-literal expressions in module blocks

### DIFF
--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -12,7 +12,7 @@ import (
 
 func SchemaForDependentModuleBlock(localName string, modMeta *module.Meta) (*schema.BodySchema, error) {
 	bodySchema := &schema.BodySchema{
-		Attributes: variablesToAttrSchemas(modMeta.Variables),
+		Attributes: variablesToAttrSchemas(modMeta.Variables, convertAttributeTypeToExprConstraints),
 	}
 
 	if localName == "" {

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -68,13 +68,19 @@ func TestSchemaForDependentModuleBlock_basic(t *testing.T) {
 	expectedDepSchema := &schema.BodySchema{
 		Attributes: map[string]*schema.AttributeSchema{
 			"example_var": {
-				Expr:        schema.LiteralTypeOnly(cty.String),
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfType: cty.String},
+					schema.LiteralTypeExpr{Type: cty.String},
+				},
 				Description: lang.PlainText("Test var"),
 				IsRequired:  true,
 				IsSensitive: true,
 			},
 			"another_var": {
-				Expr:       schema.LiteralTypeOnly(cty.String),
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfType: cty.String},
+					schema.LiteralTypeExpr{Type: cty.String},
+				},
 				IsOptional: true,
 			},
 		},

--- a/schema/schema_merge_v015_test.go
+++ b/schema/schema_merge_v015_test.go
@@ -521,8 +521,11 @@ var moduleWithDependency = schema.BlockSchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"test": {
 					Description: lang.PlainText("test var"),
-					Expr:        schema.LiteralTypeOnly(cty.String),
-					IsRequired:  true,
+					Expr: schema.ExprConstraints{
+						schema.TraversalExpr{OfType: cty.String},
+						schema.LiteralTypeExpr{Type: cty.String},
+					},
+					IsRequired: true,
 				},
 			},
 		},

--- a/schema/variable_schema.go
+++ b/schema/variable_schema.go
@@ -9,11 +9,13 @@ import (
 
 func SchemaForVariables(vars map[string]module.Variable) (*schema.BodySchema, error) {
 	return &schema.BodySchema{
-		Attributes: variablesToAttrSchemas(vars),
+		Attributes: variablesToAttrSchemas(vars, schema.LiteralTypeOnly),
 	}, nil
 }
 
-func variablesToAttrSchemas(vars map[string]module.Variable) map[string]*schema.AttributeSchema {
+type exprFunc func(cty.Type) schema.ExprConstraints
+
+func variablesToAttrSchemas(vars map[string]module.Variable, exprFunc exprFunc) map[string]*schema.AttributeSchema {
 	varSchemas := make(map[string]*schema.AttributeSchema)
 
 	for name, v := range vars {
@@ -26,7 +28,7 @@ func variablesToAttrSchemas(vars map[string]module.Variable) map[string]*schema.
 		}
 
 		aSchema := &schema.AttributeSchema{
-			Expr:        schema.LiteralTypeOnly(varType),
+			Expr:        exprFunc(varType),
 			IsSensitive: v.IsSensitive,
 		}
 		if v.Description != "" {


### PR DESCRIPTION
As reported in https://github.com/hashicorp/terraform-ls/issues/620 prior to this patch, references would not be recognized within the `module` block, except for static/core attributes like `count`:

```hcl
module "example" {
  source "..."
  foo = var.bar # HERE
}
```

This patch makes the module use the same the expression type generation logic we use for all other provider-specific attributes (applied to most attributes within `provider`, `resource` and `data` blocks).
