### PR TITLE
ci: Reduce timeout & token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,16 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   GOPROXY: https://proxy.golang.org/
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       matrix:
         os:


### PR DESCRIPTION
This aligns the config more with the one we use for `terraform-ls`.

Namely the default GHA timeout is 6 hours and there are known cases of builds sometimes getting stuck (due to what seems a temporary issue on GitHub's side usually) which in turn consumes credits, i.e. cost money. Our builds here almost never cross the 2 min mark, but I set it conservatively to 5 minutes.

The [default token permissions](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) depend on Enterprise policy settings, but either way we don't need anything other than cloning the repo to run the tests, so this patch reflects that.