### PR TITLE
earlydecoder: Decode backend block

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,0 +1,21 @@
+package backend
+
+type BackendData interface {
+	Copy() BackendData
+}
+
+type UnknownBackendData struct{}
+
+func (*UnknownBackendData) Copy() BackendData {
+	return &UnknownBackendData{}
+}
+
+type Remote struct {
+	Hostname string
+}
+
+func (r *Remote) Copy() BackendData {
+	return &Remote{
+		Hostname: r.Hostname,
+	}
+}

--- a/earlydecoder/backend.go
+++ b/earlydecoder/backend.go
@@ -1,0 +1,29 @@
+package earlydecoder
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform-schema/backend"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func decodeBackendsBlock(block *hcl.Block) (backend.BackendData, hcl.Diagnostics) {
+	bType := block.Labels[0]
+	attrs, diags := block.Body.JustAttributes()
+
+	switch bType {
+	case "remote":
+		if attr, ok := attrs["hostname"]; ok {
+			val, vDiags := attr.Expr.Value(nil)
+			diags = append(diags, vDiags...)
+			if val.IsWhollyKnown() && val.Type() == cty.String {
+				return &backend.Remote{
+					Hostname: val.AsString(),
+				}, nil
+			}
+		}
+
+		return &backend.Remote{}, nil
+	}
+
+	return &backend.UnknownBackendData{}, diags
+}

--- a/earlydecoder/schema.go
+++ b/earlydecoder/schema.go
@@ -42,6 +42,10 @@ var terraformBlockSchema = &hcl.BodySchema{
 		{
 			Type: "required_providers",
 		},
+		{
+			Type:       "backend",
+			LabelNames: []string{"type"},
+		},
 	},
 }
 

--- a/module/meta.go
+++ b/module/meta.go
@@ -3,16 +3,23 @@ package module
 import (
 	"github.com/hashicorp/go-version"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
+	"github.com/hashicorp/terraform-schema/backend"
 )
 
 type Meta struct {
 	Path string
 
+	Backend              *Backend
 	ProviderReferences   map[ProviderRef]tfaddr.Provider
 	ProviderRequirements map[tfaddr.Provider]version.Constraints
 	CoreRequirements     version.Constraints
 	Variables            map[string]Variable
 	Outputs              map[string]Output
+}
+
+type Backend struct {
+	Type string
+	Data backend.BackendData
 }
 
 type ProviderRef struct {


### PR DESCRIPTION
This allows us to decode the `backend` block in `earlydecoder` in a minimal way, just to be able to use the data in telemetry in https://github.com/hashicorp/terraform-ls/pull/681