### PR TITLE
schema: Unpublish SchemaForDependentModuleBlock

### DIFF
--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func SchemaForDependentModuleBlock(localName string, modMeta *module.Meta) (*schema.BodySchema, error) {
+func schemaForDependentModuleBlock(localName string, modMeta *module.Meta) (*schema.BodySchema, error) {
 	bodySchema := &schema.BodySchema{
 		Attributes: variablesToAttrSchemas(modMeta.Variables, convertAttributeTypeToExprConstraints),
 	}

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSchemaForDependentModuleBlock_emptyMeta(t *testing.T) {
 	meta := &module.Meta{}
-	depSchema, err := SchemaForDependentModuleBlock("refname", meta)
+	depSchema, err := schemaForDependentModuleBlock("refname", meta)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestSchemaForDependentModuleBlock_basic(t *testing.T) {
 			},
 		},
 	}
-	depSchema, err := SchemaForDependentModuleBlock("refname", meta)
+	depSchema, err := schemaForDependentModuleBlock("refname", meta)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -201,7 +201,7 @@ func (m *SchemaMerger) SchemaForModule(meta *module.Meta) (*schema.BodySchema, e
 				},
 			}
 
-			depSchema, err := SchemaForDependentModuleBlock(module.LocalName, modMeta)
+			depSchema, err := schemaForDependentModuleBlock(module.LocalName, modMeta)
 			if err == nil {
 				mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 			}


### PR DESCRIPTION
This method is not used outside of the library by the LS, so there is not need for it to be public.
