### PR TITLE
Use OriginForTarget to connect `tfvars` w/ variables

### DIFF
--- a/schema/variable_schema.go
+++ b/schema/variable_schema.go
@@ -3,16 +3,33 @@ package schema
 import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
 	"github.com/hashicorp/terraform-schema/module"
 	"github.com/zclconf/go-cty/cty"
 )
 
-func SchemaForVariables(vars map[string]module.Variable) (*schema.BodySchema, error) {
+func SchemaForVariables(vars map[string]module.Variable, path string) (*schema.BodySchema, error) {
 	attributes := make(map[string]*schema.AttributeSchema)
 
 	for name, modVar := range vars {
 		aSchema := moduleVarToAttribute(modVar)
-		aSchema.Expr = schema.LiteralTypeOnly(typeOfModuleVar(modVar))
+		varType := typeOfModuleVar(modVar)
+		aSchema.Expr = schema.LiteralTypeOnly(varType)
+		aSchema.OriginForTarget = &schema.PathTarget{
+			Address: schema.Address{
+				schema.StaticStep{Name: "var"},
+				schema.AttrNameStep{},
+			},
+			Path: lang.Path{
+				Path:       path,
+				LanguageID: ModuleLanguageID,
+			},
+			Constraints: schema.Constraints{
+				ScopeId: refscope.VariableScope,
+				Type:    varType,
+			},
+		}
+
 		attributes[name] = aSchema
 	}
 

--- a/schema/variable_schema_test.go
+++ b/schema/variable_schema_test.go
@@ -39,6 +39,11 @@ func TestSchemaForVariables(t *testing.T) {
 					},
 					IsRequired: true,
 					Expr:       schema.LiteralTypeOnly(cty.String),
+					OriginForTarget: &schema.PathTarget{
+						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
+						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
+						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.String},
+					},
 				},
 			}},
 		},
@@ -64,6 +69,11 @@ func TestSchemaForVariables(t *testing.T) {
 					},
 					IsOptional: true,
 					Expr:       schema.LiteralTypeOnly(cty.String),
+					OriginForTarget: &schema.PathTarget{
+						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
+						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
+						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.String},
+					},
 				},
 				"id": {
 					Description: lang.MarkupContent{
@@ -73,6 +83,11 @@ func TestSchemaForVariables(t *testing.T) {
 					Expr:        schema.LiteralTypeOnly(cty.Number),
 					IsSensitive: true,
 					IsRequired:  true,
+					OriginForTarget: &schema.PathTarget{
+						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
+						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
+						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.Number},
+					},
 				},
 			}},
 		},
@@ -98,6 +113,11 @@ func TestSchemaForVariables(t *testing.T) {
 					},
 					IsOptional: true,
 					Expr:       schema.LiteralTypeOnly(cty.String),
+					OriginForTarget: &schema.PathTarget{
+						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
+						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
+						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.String},
+					},
 				},
 				"id": {
 					Description: lang.MarkupContent{
@@ -106,14 +126,20 @@ func TestSchemaForVariables(t *testing.T) {
 					},
 					Expr:       schema.LiteralTypeOnly(cty.Number),
 					IsOptional: true,
+					OriginForTarget: &schema.PathTarget{
+						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
+						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
+						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.Number},
+					},
 				},
 			}},
 		},
 	}
 
+	path := "./local"
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
-			actualSchema, err := SchemaForVariables(tc.variables)
+			actualSchema, err := SchemaForVariables(tc.variables, path)
 
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This is to leverage the new `schema.OriginForTarget` field to express that variables in `tfvars` act as origins, targeting the relevant variables.

Required for https://github.com/hashicorp/terraform-ls/issues/618