### PR TITLE
module: Implement `Equals` functions

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -2,12 +2,18 @@ package backend
 
 type BackendData interface {
 	Copy() BackendData
+	Equals(BackendData) bool
 }
 
 type UnknownBackendData struct{}
 
 func (*UnknownBackendData) Copy() BackendData {
 	return &UnknownBackendData{}
+}
+
+func (*UnknownBackendData) Equals(d BackendData) bool {
+	_, ok := d.(*UnknownBackendData)
+	return ok
 }
 
 type Remote struct {
@@ -18,4 +24,13 @@ func (r *Remote) Copy() BackendData {
 	return &Remote{
 		Hostname: r.Hostname,
 	}
+}
+
+func (r *Remote) Equals(d BackendData) bool {
+	data, ok := d.(*Remote)
+	if !ok {
+		return false
+	}
+
+	return data.Hostname == r.Hostname
 }

--- a/module/meta.go
+++ b/module/meta.go
@@ -22,6 +22,22 @@ type Backend struct {
 	Data backend.BackendData
 }
 
+func (be *Backend) Equals(b *Backend) bool {
+	if be == nil && b == nil {
+		return true
+	}
+
+	if be == nil || b == nil {
+		return false
+	}
+
+	if be.Type != b.Type {
+		return false
+	}
+
+	return be.Data.Equals(b.Data)
+}
+
 type ProviderRef struct {
 	LocalName string
 

--- a/module/meta.go
+++ b/module/meta.go
@@ -11,10 +11,30 @@ type Meta struct {
 
 	Backend              *Backend
 	ProviderReferences   map[ProviderRef]tfaddr.Provider
-	ProviderRequirements map[tfaddr.Provider]version.Constraints
+	ProviderRequirements ProviderRequirements
 	CoreRequirements     version.Constraints
 	Variables            map[string]Variable
 	Outputs              map[string]Output
+}
+
+type ProviderRequirements map[tfaddr.Provider]version.Constraints
+
+func (pr ProviderRequirements) Equals(reqs ProviderRequirements) bool {
+	if len(pr) != len(reqs) {
+		return false
+	}
+
+	for pAddr, vCons := range pr {
+		c, ok := reqs[pAddr]
+		if !ok {
+			return false
+		}
+		if !vCons.Equals(c) {
+			return false
+		}
+	}
+
+	return true
 }
 
 type Backend struct {

--- a/module/meta_test.go
+++ b/module/meta_test.go
@@ -1,0 +1,96 @@
+package module
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-schema/backend"
+)
+
+func TestBackend_Equals(t *testing.T) {
+	testCases := []struct {
+		first, second *Backend
+		expectEqual   bool
+	}{
+		{
+			nil,
+			nil,
+			true,
+		},
+		{
+			&Backend{
+				Type: "s3",
+				Data: &backend.UnknownBackendData{},
+			},
+			&Backend{
+				Type: "s3",
+				Data: &backend.UnknownBackendData{},
+			},
+			true,
+		},
+		{
+			&Backend{
+				Type: "s3",
+				Data: &backend.UnknownBackendData{},
+			},
+			&Backend{
+				Type: "s4",
+				Data: &backend.UnknownBackendData{},
+			},
+			false,
+		},
+		{
+			&Backend{
+				Type: "remote",
+				Data: &backend.Remote{},
+			},
+			&Backend{
+				Type: "remote",
+				Data: &backend.Remote{},
+			},
+			true,
+		},
+		{
+			&Backend{
+				Type: "remote",
+				Data: &backend.Remote{
+					Hostname: "foobar",
+				},
+			},
+			&Backend{
+				Type: "remote",
+				Data: &backend.Remote{
+					Hostname: "foobar",
+				},
+			},
+			true,
+		},
+		{
+			&Backend{
+				Type: "remote",
+				Data: &backend.Remote{
+					Hostname: "foobar",
+				},
+			},
+			&Backend{
+				Type: "remote",
+				Data: &backend.Remote{
+					Hostname: "bar",
+				},
+			},
+			false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			equals := tc.first.Equals(tc.second)
+			if tc.expectEqual != equals {
+				if tc.expectEqual {
+					t.Fatalf("expected backends to be equal\nfirst: %#v\nsecond: %#v", tc.first, tc.second)
+				}
+				t.Fatalf("expected backends to mismatch\nfirst: %#v\nsecond: %#v", tc.first, tc.second)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is to enable comparison of module data in memdb in LS, as per https://github.com/hashicorp/terraform-ls/pull/758 to avoid sending unnecessary telemetry notifications.