### PR TITLE
schema: Remove duplicate code from SchemaMerger

### DIFF
--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -213,7 +213,7 @@ func (m *SchemaMerger) SchemaForModule(meta *module.Meta) (*schema.BodySchema, e
 
 			// There's likely more edge cases with how source address can be represented in config
 			// vs in module manifest, but for now we at least account for the common case of TF Registry
-			if strings.HasPrefix(module.SourceAddr, "registry.terraform.io/") {
+			if err == nil && strings.HasPrefix(module.SourceAddr, "registry.terraform.io/") {
 				shortName := strings.TrimPrefix(module.SourceAddr, "registry.terraform.io/")
 
 				depKeys := schema.DependencyKeys{
@@ -230,10 +230,7 @@ func (m *SchemaMerger) SchemaForModule(meta *module.Meta) (*schema.BodySchema, e
 					},
 				}
 
-				depSchema, err := schemaForDependentModuleBlock(module.LocalName, modMeta)
-				if err == nil {
-					mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
-				}
+				mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 			}
 		}
 	}


### PR DESCRIPTION
I was a little too trigger happy when merging https://github.com/hashicorp/terraform-schema/pull/94 😅 

So this is to address @dbanck 's valid point about some duplicate code there.