### PR TITLE
Add DocsLink for remote module source attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.14
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-version v1.4.0
-	github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592
+	github.com/hashicorp/hcl-lang v0.0.0-20220421093840-480fdfd2ecb5
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/terraform-json v0.13.0
-	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896
+	github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
@@ -29,14 +28,14 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592 h1:pSTtkCAbU+SLxw6J59ihqFDX5lJ9xR/fhqaOng1kQXY=
-github.com/hashicorp/hcl-lang v0.0.0-20220406121211-c20527a75592/go.mod h1:oQgcOV8OizFyZfZh3FbQSsQtvtTv8hD23MLAxfn3E+E=
+github.com/hashicorp/hcl-lang v0.0.0-20220421093840-480fdfd2ecb5 h1:A18R+0Emk5YuXo22u44wxwHAnNHLDK6NHxXl2CIQGlU=
+github.com/hashicorp/hcl-lang v0.0.0-20220421093840-480fdfd2ecb5/go.mod h1:oQgcOV8OizFyZfZh3FbQSsQtvtTv8hD23MLAxfn3E+E=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
-github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 h1:1FGtlkJw87UsTMg5s8jrekrHmUPUJaMcu6ELiVhQrNw=
-github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896/go.mod h1:bzBPnUIkI0RxauU8Dqo+2KrZZ28Cf48s8V6IHt3p4co=
+github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473 h1:Vp3YMcnM+TvVMV5TplAhGeuzz3A0562AywL32y71y3Y=
+github.com/hashicorp/terraform-registry-address v0.0.0-20220422093245-eb7bcc2ff473/go.mod h1:bdLC+qQlJIBHKbCMA6GipcuaKjmjcvZlnVdpU583z3Y=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/module/meta.go
+++ b/module/meta.go
@@ -70,5 +70,6 @@ type ProviderRef struct {
 type ModuleCall struct {
 	LocalName  string
 	SourceAddr string
+	Version    string
 	Path       string
 }

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -116,15 +116,14 @@ func schemaForDependentModuleBlock(module module.ModuleCall, modMeta *module.Met
 	}
 
 	moduleSourceRegistry, err := tfaddr.ParseRawModuleSourceRegistry(module.SourceAddr)
-	if err == nil {
+	if err == nil && moduleSourceRegistry.PackageAddr.Host == "registry.terraform.io" {
 		version := module.Version
 		if version == "" {
 			version = "latest"
 		}
 		bodySchema.DocsLink = &schema.DocsLink{
 			URL: fmt.Sprintf(
-				`https://%s/modules/%s/%s`,
-				moduleSourceRegistry.PackageAddr.Host.ForDisplay(),
+				`https://registry.terraform.io/modules/%s/%s`,
 				moduleSourceRegistry.PackageAddr.ForRegistryProtocol(),
 				version,
 			),

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -382,6 +382,34 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				},
 			},
 		},
+		{
+			"remote module on unknown registry",
+			&module.Meta{
+				Path:      "example.com/terraform-aws-modules/vpc/aws",
+				Variables: map[string]module.Variable{},
+				Outputs:   map[string]module.Output{},
+				Filenames: nil,
+			},
+			module.ModuleCall{
+				LocalName:  "vpc",
+				SourceAddr: "example.com/terraform-aws-modules/vpc/aws",
+				Version:    "1.33.7",
+			},
+			&schema.BodySchema{
+				Attributes: map[string]*schema.AttributeSchema{},
+				TargetableAs: []*schema.Targetable{
+					{
+						Address: lang.Address{
+							lang.RootStep{Name: "module"},
+							lang.AttrStep{Name: "vpc"},
+						},
+						ScopeId:           refscope.ModuleScope,
+						AsType:            cty.Object(map[string]cty.Type{}),
+						NestedTargetables: []*schema.Targetable{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -207,7 +207,7 @@ func (m *SchemaMerger) SchemaForModule(meta *module.Meta) (*schema.BodySchema, e
 				},
 			}
 
-			depSchema, err := schemaForDependentModuleBlock(module.LocalName, modMeta)
+			depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 			if err == nil {
 				mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 			}


### PR DESCRIPTION
Required for https://github.com/hashicorp/vscode-terraform/issues/673

Depends on 
* https://github.com/hashicorp/hcl-lang/pull/115
* https://github.com/hashicorp/terraform-registry-address/pull/7

This PR adds a `DocsLink` to the depended module schema if the module is a registry (e.g. registry.terraform.io) one.

I added a `Version` field to `ModuleCall`, required for building the docs link. To populate this field a change in `terraform-ls` is required (https://github.com/hashicorp/terraform-ls/pull/874).
https://github.com/hashicorp/terraform-schema/blob/af1666c4d1e2929514d98d6a1a2a1314275d5405/module/meta.go#L70-L75