### PR TITLE
schema.ProviderSchema: remove unused Module field

### DIFF
--- a/schema/provider_schema.go
+++ b/schema/provider_schema.go
@@ -10,7 +10,6 @@ type ProviderSchema struct {
 	Provider    *schema.BodySchema
 	Resources   map[string]*schema.BodySchema
 	DataSources map[string]*schema.BodySchema
-	Module      *schema.BodySchema
 }
 
 func (ps *ProviderSchema) Copy() *ProviderSchema {


### PR DESCRIPTION
It looks like this was just accidentally introduced as part of https://github.com/hashicorp/terraform-schema/pull/58/files#diff-317e02a51a6ead9a061899759a8565d2c4aae611c77d02c96d08314b39b1c327R26