### PR TITLE
Introduce `LocalSourceAddr` for modules

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1161,6 +1161,28 @@ module "name" {
 			},
 			nil,
 		},
+		{
+			"modules with local source",
+			`
+module "name" {
+	source = "./local"
+}`,
+			&module.Meta{
+				Path:                 path,
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls: map[string]module.DeclaredModuleCall{
+					"name": {
+						LocalName:  "name",
+						SourceAddr: module.LocalSourceAddr("./local"),
+					},
+				},
+			},
+			nil,
+		},
 	}
 
 	runTestCases(testCases, t, path)

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -2,6 +2,7 @@ package earlydecoder
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -310,8 +311,9 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 			registryAddr, err := tfaddr.ParseModuleSource(source)
 			if err == nil {
 				sourceAddr = registryAddr
+			} else if isModuleSourceLocal(source) {
+				sourceAddr = module.LocalSourceAddr(source)
 			}
-			// TODO: module.LocalSourceAddr
 
 			mod.ModuleCalls[name] = &module.DeclaredModuleCall{
 				LocalName:  name,
@@ -371,4 +373,13 @@ func decodeProviderAttribute(attr *hcl.Attribute) (module.ProviderRef, hcl.Diagn
 			Subject:  attr.Expr.Range().Ptr(),
 		},
 	}
+}
+
+func isModuleSourceLocal(raw string) bool {
+	for _, prefix := range module.ModuleSourceLocalPrefixes {
+		if strings.HasPrefix(raw, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -4,6 +4,13 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+var ModuleSourceLocalPrefixes = []string{
+	"./",
+	"../",
+	".\\",
+	"..\\",
+}
+
 type ModuleCalls struct {
 	Installed map[string]InstalledModuleCall
 	Declared  map[string]DeclaredModuleCall
@@ -27,4 +34,11 @@ type ModuleSourceAddr interface {
 	String() string
 }
 
-// TODO: type LocalSourceAddr
+type LocalSourceAddr string
+
+func (lsa LocalSourceAddr) ForDisplay() string {
+	return string(lsa)
+}
+func (lsa LocalSourceAddr) String() string {
+	return string(lsa)
+}


### PR DESCRIPTION
On module loading, we now check for local module sources as well as for registry modules.

This is a requirement for using configuration as the primary source for module.calls: https://github.com/hashicorp/terraform-ls/issues/725