### PR TITLE
Introduce `UnknownSourceAddr` for `ModuleSourceAddr`

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1087,7 +1087,8 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName: "name",
+						LocalName:  "name",
+						SourceAddr: module.UnknownSourceAddr(""),
 					},
 				},
 			},
@@ -1130,8 +1131,9 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName: "name",
-						Version:   version.MustConstraints(version.NewConstraint("> 3.0.0, < 4.0.0")),
+						LocalName:  "name",
+						SourceAddr: module.UnknownSourceAddr(""),
+						Version:    version.MustConstraints(version.NewConstraint("> 3.0.0, < 4.0.0")),
 					},
 				},
 			},
@@ -1178,6 +1180,28 @@ module "name" {
 					"name": {
 						LocalName:  "name",
 						SourceAddr: module.LocalSourceAddr("./local"),
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"modules with unknown source",
+			`
+module "name" {
+	source = "github.com/terraform-aws-modules/terraform-aws-security-group"
+}`,
+			&module.Meta{
+				Path:                 path,
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls: map[string]module.DeclaredModuleCall{
+					"name": {
+						LocalName:  "name",
+						SourceAddr: module.UnknownSourceAddr("github.com/terraform-aws-modules/terraform-aws-security-group"),
 					},
 				},
 			},

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -313,6 +313,8 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 				sourceAddr = registryAddr
 			} else if isModuleSourceLocal(source) {
 				sourceAddr = module.LocalSourceAddr(source)
+			} else {
+				sourceAddr = module.UnknownSourceAddr(source)
 			}
 
 			mod.ModuleCalls[name] = &module.DeclaredModuleCall{

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -42,3 +42,12 @@ func (lsa LocalSourceAddr) ForDisplay() string {
 func (lsa LocalSourceAddr) String() string {
 	return string(lsa)
 }
+
+type UnknownSourceAddr string
+
+func (usa UnknownSourceAddr) ForDisplay() string {
+	return string(usa)
+}
+func (usa UnknownSourceAddr) String() string {
+	return string(usa)
+}


### PR DESCRIPTION
This PR adds `UnknownSourceAddr` as type for all module sources, which aren't local or from the registry.

The current primary usage is to have these modules appear in the module calls explorer pane with their corresponding icon.
<img width="214" alt="CleanShot 2022-07-06 at 11 36 08@2x" src="https://user-images.githubusercontent.com/45985/177521135-a63ba565-a422-455a-b62a-37a2928ca9d1.png">
 