### PR TITLE
schema: add 1.1 `moved` block

### DIFF
--- a/internal/schema/1.1/moved.go
+++ b/internal/schema/1.1/moved.go
@@ -13,7 +13,6 @@ var movedBlockSchema = &schema.BlockSchema{
 		Attributes: map[string]*schema.AttributeSchema{
 			"from": {
 				Expr: schema.ExprConstraints{
-					schema.TraversalExpr{OfScopeId: refscope.DataScope},
 					schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
 					schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
 				},
@@ -22,7 +21,6 @@ var movedBlockSchema = &schema.BlockSchema{
 			},
 			"to": {
 				Expr: schema.ExprConstraints{
-					schema.TraversalExpr{OfScopeId: refscope.DataScope},
 					schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
 					schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
 				},

--- a/internal/schema/1.1/moved.go
+++ b/internal/schema/1.1/moved.go
@@ -1,0 +1,34 @@
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+)
+
+var movedBlockSchema = &schema.BlockSchema{
+	Description: lang.Markdown("Refactoring declaration to specify what address to move where"),
+	Body: &schema.BodySchema{
+		HoverURL: "https://www.terraform.io/language/modules/develop/refactoring#moved-block-syntax",
+		Attributes: map[string]*schema.AttributeSchema{
+			"from": {
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfScopeId: refscope.DataScope},
+					schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
+					schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+				},
+				IsRequired:  true,
+				Description: lang.Markdown("Source address to move away from"),
+			},
+			"to": {
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfScopeId: refscope.DataScope},
+					schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
+					schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+				},
+				IsRequired:  true,
+				Description: lang.Markdown("Destination address to move to"),
+			},
+		},
+	},
+}

--- a/internal/schema/1.1/root.go
+++ b/internal/schema/1.1/root.go
@@ -9,6 +9,7 @@ import (
 
 func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs := v015_mod.ModuleSchema(v)
+	bs.Blocks["moved"] = movedBlockSchema
 	bs.Blocks["terraform"] = patchTerraformBlockSchema(bs.Blocks["terraform"], v)
 	return bs
 }


### PR DESCRIPTION
See https://github.com/hashicorp/terraform/blob/v1.1/CHANGELOG.md#110-december-08-2021 and https://www.terraform.io/language/modules/develop/refactoring#moved-block-syntax

Fixes https://github.com/hashicorp/terraform-schema/issues/63

This will be useful to get merged before https://github.com/hashicorp/terraform-ls/issues/993 in case we need to restructure the existing schemas in any more significant way.

--- 

## LS UX
<img width="782" alt="Screenshot 2022-07-07 at 08 50 03" src="https://user-images.githubusercontent.com/287584/177721081-3689c062-5f1e-4ff8-98a3-4dfc8f108f91.png">
<img width="797" alt="Screenshot 2022-07-07 at 08 50 14" src="https://user-images.githubusercontent.com/287584/177721086-a5a6ec0c-17ab-4b73-a0f8-f0839757e4b7.png">

