### PR TITLE
Return an empty or missing module source as `nil`

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1087,8 +1087,7 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: module.UnknownSourceAddr(""),
+						LocalName: "name",
 					},
 				},
 			},
@@ -1131,9 +1130,8 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: module.UnknownSourceAddr(""),
-						Version:    version.MustConstraints(version.NewConstraint("> 3.0.0, < 4.0.0")),
+						LocalName: "name",
+						Version:   version.MustConstraints(version.NewConstraint("> 3.0.0, < 4.0.0")),
 					},
 				},
 			},

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -313,7 +313,7 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 				sourceAddr = registryAddr
 			} else if isModuleSourceLocal(source) {
 				sourceAddr = module.LocalSourceAddr(source)
-			} else {
+			} else if source != "" {
 				sourceAddr = module.UnknownSourceAddr(source)
 			}
 


### PR DESCRIPTION
Previously we treated this as `module.UnknownSourceAddr("")`