### PR TITLE
earlydecoder/schema: Infer schema for local modules

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1087,7 +1087,8 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName: "name",
+						LocalName:  "name",
+						InputNames: []string{},
 					},
 				},
 			},
@@ -1110,6 +1111,7 @@ module "name" {
 					"name": {
 						LocalName:  "name",
 						SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
+						InputNames: []string{},
 					},
 				},
 			},
@@ -1130,8 +1132,9 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName: "name",
-						Version:   version.MustConstraints(version.NewConstraint("> 3.0.0, < 4.0.0")),
+						LocalName:  "name",
+						Version:    version.MustConstraints(version.NewConstraint("> 3.0.0, < 4.0.0")),
+						InputNames: []string{},
 					},
 				},
 			},
@@ -1156,6 +1159,7 @@ module "name" {
 						LocalName:  "name",
 						SourceAddr: tfaddr.MustParseModuleSource("terraform-aws-modules/vpc/aws"),
 						Version:    version.MustConstraints(version.NewConstraint("1.0.0")),
+						InputNames: []string{},
 					},
 				},
 			},
@@ -1178,6 +1182,34 @@ module "name" {
 					"name": {
 						LocalName:  "name",
 						SourceAddr: module.LocalSourceAddr("./local"),
+						InputNames: []string{},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"modules with local source and inputs",
+			`
+module "name" {
+	source = "./local"
+	one = "one"
+	two = 42
+}`,
+			&module.Meta{
+				Path:                 path,
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls: map[string]module.DeclaredModuleCall{
+					"name": {
+						LocalName:  "name",
+						SourceAddr: module.LocalSourceAddr("./local"),
+						InputNames: []string{
+							"one", "two",
+						},
 					},
 				},
 			},
@@ -1200,6 +1232,7 @@ module "name" {
 					"name": {
 						LocalName:  "name",
 						SourceAddr: module.UnknownSourceAddr("github.com/terraform-aws-modules/terraform-aws-security-group"),
+						InputNames: []string{},
 					},
 				},
 			},

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -30,6 +30,21 @@ type DeclaredModuleCall struct {
 	LocalName  string
 	SourceAddr ModuleSourceAddr
 	Version    version.Constraints
+	InputNames []string
+}
+
+func (mc DeclaredModuleCall) Copy() DeclaredModuleCall {
+	inputNames := make([]string, len(mc.InputNames))
+	for i, name := range mc.InputNames {
+		inputNames[i] = name
+	}
+
+	return DeclaredModuleCall{
+		LocalName:  mc.LocalName,
+		SourceAddr: mc.SourceAddr,
+		Version:    mc.Version,
+		InputNames: inputNames,
+	}
 }
 
 type ModuleSourceAddr interface {


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-schema/pull/125

--- 

Collecting reference origins in the context of a `module` block expects the underlying module files to be parsed and metadata to be also available, such that we can use it to construct the dependent schema for inputs.

When walking through the hierarchy we practically cannot guarantee that one module will be indexed before another and re-indexing modules seems wasteful to provide such a guarantee. Prior to https://github.com/hashicorp/terraform-ls/pull/997 we were just mostly lucky this didn't come up.

Therefore this PR proposes adding a "fallback" blind schema for any dependent module, where we don't try to be accurate with types, but essentially infer the schema from the raw configuration. Given that we always re-build the schema prior to completion/hover/etc., we can still provide more accurate schema if it's available.

The only downside is slightly less detailed origins after the collection which won't be re-collected unless something else triggers the re-collection. We could theoretically gather the type for each input as well, but I'm not entirely sure it's worth the effort/CPU given that we'll gather that later (again) anyway.