### PR TITLE
Update static pointer `BlockSchema` definitions to function calls

### DIFF
--- a/internal/schema/0.12/locals_block.go
+++ b/internal/schema/0.12/locals_block.go
@@ -8,24 +8,26 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-var localsBlockSchema = &schema.BlockSchema{
-	SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Locals},
-	Description: lang.Markdown("Local values assigning names to expressions, so you can use these multiple times without repetition\n" +
-		"e.g. `service_name = \"forum\"`"),
-	Body: &schema.BodySchema{
-		AnyAttribute: &schema.AttributeSchema{
-			Address: &schema.AttributeAddrSchema{
-				Steps: []schema.AddrStep{
-					schema.StaticStep{Name: "local"},
-					schema.AttrNameStep{},
+func localsBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Locals},
+		Description: lang.Markdown("Local values assigning names to expressions, so you can use these multiple times without repetition\n" +
+			"e.g. `service_name = \"forum\"`"),
+		Body: &schema.BodySchema{
+			AnyAttribute: &schema.AttributeSchema{
+				Address: &schema.AttributeAddrSchema{
+					Steps: []schema.AddrStep{
+						schema.StaticStep{Name: "local"},
+						schema.AttrNameStep{},
+					},
+					ScopeId:    refscope.LocalScope,
+					AsExprType: true,
 				},
-				ScopeId:    refscope.LocalScope,
-				AsExprType: true,
-			},
-			Expr: schema.ExprConstraints{
-				schema.TraversalExpr{OfType: cty.DynamicPseudoType},
-				schema.LiteralTypeExpr{Type: cty.DynamicPseudoType},
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfType: cty.DynamicPseudoType},
+					schema.LiteralTypeExpr{Type: cty.DynamicPseudoType},
+				},
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/0.12/module_block.go
+++ b/internal/schema/0.12/module_block.go
@@ -8,68 +8,70 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-var moduleBlockSchema = &schema.BlockSchema{
-	Address: &schema.BlockAddrSchema{
-		Steps: []schema.AddrStep{
-			schema.StaticStep{Name: "module"},
-			schema.LabelStep{Index: 0},
-		},
-		FriendlyName: "module",
-		ScopeId:      refscope.ModuleScope,
-		AsReference:  true,
-	},
-	SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Module},
-	Labels: []*schema.LabelSchema{
-		{
-			Name:                   "name",
-			SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
-			Description:            lang.PlainText("Reference Name"),
-		},
-	},
-	Description: lang.PlainText("Module block to call a locally or remotely stored module"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"source": {
-				Expr: schema.LiteralTypeOnly(cty.String),
-				Description: lang.Markdown("Source where to load the module from, " +
-					"a local directory (e.g. `./module`) or a remote address - e.g. " +
-					"`hashicorp/consul/aws` (Terraform Registry address) or " +
-					"`github.com/hashicorp/example` (GitHub)"),
-				IsRequired:             true,
-				IsDepKey:               true,
-				SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
-				CompletionHooks: lang.CompletionHooks{
-					{
-						Name: "CompleteLocalModuleSources",
-					},
-					{
-						Name: "CompleteRegistryModuleSources",
-					},
-				},
+func moduleBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "module"},
+				schema.LabelStep{Index: 0},
 			},
-			"version": {
-				Expr:       schema.LiteralTypeOnly(cty.String),
-				IsOptional: true,
-				Description: lang.Markdown("Constraint to set the version of the module, e.g. `~> 1.0`." +
-					" Only applicable to modules in a module registry."),
-				CompletionHooks: lang.CompletionHooks{
-					{
-						Name: "CompleteRegistryModuleVersions",
-					},
-				},
+			FriendlyName: "module",
+			ScopeId:      refscope.ModuleScope,
+			AsReference:  true,
+		},
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Module},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Reference Name"),
 			},
-			"providers": {
-				Expr: schema.ExprConstraints{
-					schema.MapExpr{
-						Name: "map of provider references",
-						Elem: schema.ExprConstraints{
-							schema.TraversalExpr{OfScopeId: refscope.ProviderScope},
+		},
+		Description: lang.PlainText("Module block to call a locally or remotely stored module"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"source": {
+					Expr: schema.LiteralTypeOnly(cty.String),
+					Description: lang.Markdown("Source where to load the module from, " +
+						"a local directory (e.g. `./module`) or a remote address - e.g. " +
+						"`hashicorp/consul/aws` (Terraform Registry address) or " +
+						"`github.com/hashicorp/example` (GitHub)"),
+					IsRequired:             true,
+					IsDepKey:               true,
+					SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "CompleteLocalModuleSources",
+						},
+						{
+							Name: "CompleteRegistryModuleSources",
 						},
 					},
 				},
-				IsOptional:  true,
-				Description: lang.Markdown("Explicit mapping of providers which the module uses"),
+				"version": {
+					Expr:       schema.LiteralTypeOnly(cty.String),
+					IsOptional: true,
+					Description: lang.Markdown("Constraint to set the version of the module, e.g. `~> 1.0`." +
+						" Only applicable to modules in a module registry."),
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "CompleteRegistryModuleVersions",
+						},
+					},
+				},
+				"providers": {
+					Expr: schema.ExprConstraints{
+						schema.MapExpr{
+							Name: "map of provider references",
+							Elem: schema.ExprConstraints{
+								schema.TraversalExpr{OfScopeId: refscope.ProviderScope},
+							},
+						},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("Explicit mapping of providers which the module uses"),
+				},
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/0.12/output_block.go
+++ b/internal/schema/0.12/output_block.go
@@ -8,59 +8,61 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-var outputBlockSchema = &schema.BlockSchema{
-	Address: &schema.BlockAddrSchema{
-		Steps: []schema.AddrStep{
-			schema.StaticStep{Name: "output"},
-			schema.LabelStep{Index: 0},
-		},
-		FriendlyName: "output",
-		ScopeId:      refscope.OutputScope,
-		AsReference:  true,
-	},
-	SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Output},
-	Labels: []*schema.LabelSchema{
-		{
-			Name:                   "name",
-			SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
-			Description:            lang.PlainText("Output Name"),
-		},
-	},
-	Description: lang.PlainText("Output value for consumption by another module or a human interacting via the UI"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"description": {
-				Expr:        schema.LiteralTypeOnly(cty.String),
-				IsOptional:  true,
-				Description: lang.PlainText("Human-readable description of the output (for documentation and UI)"),
+func outputBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "output"},
+				schema.LabelStep{Index: 0},
 			},
-			"value": {
-				Expr: schema.ExprConstraints{
-					schema.TraversalExpr{OfType: cty.DynamicPseudoType},
-					schema.LiteralTypeExpr{Type: cty.DynamicPseudoType},
+			FriendlyName: "output",
+			ScopeId:      refscope.OutputScope,
+			AsReference:  true,
+		},
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Output},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Output Name"),
+			},
+		},
+		Description: lang.PlainText("Output value for consumption by another module or a human interacting via the UI"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"description": {
+					Expr:        schema.LiteralTypeOnly(cty.String),
+					IsOptional:  true,
+					Description: lang.PlainText("Human-readable description of the output (for documentation and UI)"),
 				},
-				IsRequired:  true,
-				Description: lang.PlainText("Value, typically a reference to an attribute of a resource or a data source"),
-			},
-			"sensitive": {
-				Expr:        schema.LiteralTypeOnly(cty.Bool),
-				IsOptional:  true,
-				Description: lang.PlainText("Whether the output contains sensitive material and should be hidden in the UI"),
-			},
-			"depends_on": {
-				Expr: schema.ExprConstraints{
-					schema.TupleConsExpr{
-						Name: "set of references",
-						AnyElem: schema.ExprConstraints{
-							schema.TraversalExpr{OfScopeId: refscope.DataScope},
-							schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
-							schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+				"value": {
+					Expr: schema.ExprConstraints{
+						schema.TraversalExpr{OfType: cty.DynamicPseudoType},
+						schema.LiteralTypeExpr{Type: cty.DynamicPseudoType},
+					},
+					IsRequired:  true,
+					Description: lang.PlainText("Value, typically a reference to an attribute of a resource or a data source"),
+				},
+				"sensitive": {
+					Expr:        schema.LiteralTypeOnly(cty.Bool),
+					IsOptional:  true,
+					Description: lang.PlainText("Whether the output contains sensitive material and should be hidden in the UI"),
+				},
+				"depends_on": {
+					Expr: schema.ExprConstraints{
+						schema.TupleConsExpr{
+							Name: "set of references",
+							AnyElem: schema.ExprConstraints{
+								schema.TraversalExpr{OfScopeId: refscope.DataScope},
+								schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
+								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+							},
 						},
 					},
+					IsOptional:  true,
+					Description: lang.PlainText("Set of references to hidden dependencies (e.g. resources or data sources)"),
 				},
-				IsOptional:  true,
-				Description: lang.PlainText("Set of references to hidden dependencies (e.g. resources or data sources)"),
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/0.12/root.go
+++ b/internal/schema/0.12/root.go
@@ -17,9 +17,9 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	return &schema.BodySchema{
 		Blocks: map[string]*schema.BlockSchema{
 			"data":      datasourceBlockSchema(v),
-			"locals":    localsBlockSchema,
-			"module":    moduleBlockSchema,
-			"output":    outputBlockSchema,
+			"locals":    localsBlockSchema(),
+			"module":    moduleBlockSchema(),
+			"output":    outputBlockSchema(),
 			"provider":  providerBlockSchema(v),
 			"resource":  resourceBlockSchema(v),
 			"variable":  variableBlockSchema(v),

--- a/internal/schema/0.13/module_block.go
+++ b/internal/schema/0.13/module_block.go
@@ -9,100 +9,102 @@ import (
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
 )
 
-var moduleBlockSchema = &schema.BlockSchema{
-	Address: &schema.BlockAddrSchema{
-		Steps: []schema.AddrStep{
-			schema.StaticStep{Name: "module"},
-			schema.LabelStep{Index: 0},
-		},
-		FriendlyName: "module",
-		ScopeId:      refscope.ModuleScope,
-		AsReference:  true,
-	},
-	SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Module},
-	Labels: []*schema.LabelSchema{
-		{
-			Name:                   "name",
-			SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
-			Description:            lang.PlainText("Reference Name"),
-		},
-	},
-	Description: lang.PlainText("Module block to call a locally or remotely stored module"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"source": {
-				Expr: schema.LiteralTypeOnly(cty.String),
-				Description: lang.Markdown("Source where to load the module from, " +
-					"a local directory (e.g. `./module`) or a remote address - e.g. " +
-					"`hashicorp/consul/aws` (Terraform Registry address) or " +
-					"`github.com/hashicorp/example` (GitHub)"),
-				IsRequired:             true,
-				IsDepKey:               true,
-				SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
-				CompletionHooks: lang.CompletionHooks{
-					{
-						Name: "CompleteLocalModuleSources",
-					},
-					{
-						Name: "CompleteRegistryModuleSources",
-					},
-				},
+func moduleBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "module"},
+				schema.LabelStep{Index: 0},
 			},
-			"version": {
-				Expr:       schema.LiteralTypeOnly(cty.String),
-				IsOptional: true,
-				Description: lang.Markdown("Constraint to set the version of the module, e.g. `~> 1.0`." +
-					" Only applicable to modules in a module registry."),
-				CompletionHooks: lang.CompletionHooks{
-					{
-						Name: "CompleteRegistryModuleVersions",
-					},
-				},
+			FriendlyName: "module",
+			ScopeId:      refscope.ModuleScope,
+			AsReference:  true,
+		},
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Module},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Reference Name"),
 			},
-			"providers": {
-				Expr: schema.ExprConstraints{
-					schema.MapExpr{
-						Name: "map of provider references",
-						Elem: schema.ExprConstraints{
-							schema.TraversalExpr{OfScopeId: refscope.ProviderScope},
+		},
+		Description: lang.PlainText("Module block to call a locally or remotely stored module"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"source": {
+					Expr: schema.LiteralTypeOnly(cty.String),
+					Description: lang.Markdown("Source where to load the module from, " +
+						"a local directory (e.g. `./module`) or a remote address - e.g. " +
+						"`hashicorp/consul/aws` (Terraform Registry address) or " +
+						"`github.com/hashicorp/example` (GitHub)"),
+					IsRequired:             true,
+					IsDepKey:               true,
+					SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "CompleteLocalModuleSources",
+						},
+						{
+							Name: "CompleteRegistryModuleSources",
 						},
 					},
 				},
-				IsOptional:  true,
-				Description: lang.Markdown("Explicit mapping of providers which the module uses"),
-			},
-			"count": {
-				Expr: schema.ExprConstraints{
-					schema.TraversalExpr{OfType: cty.Number},
-					schema.LiteralTypeExpr{Type: cty.Number},
-				},
-				IsOptional:  true,
-				Description: lang.Markdown("Number of instances of this module, e.g. `3`"),
-			},
-			"for_each": {
-				Expr: schema.ExprConstraints{
-					schema.TraversalExpr{OfType: cty.Set(cty.DynamicPseudoType)},
-					schema.TraversalExpr{OfType: cty.Map(cty.DynamicPseudoType)},
-					schema.LiteralTypeExpr{Type: cty.Set(cty.DynamicPseudoType)},
-					schema.LiteralTypeExpr{Type: cty.Map(cty.DynamicPseudoType)},
-				},
-				IsOptional:  true,
-				Description: lang.Markdown("A set or a map where each item represents an instance of this module"),
-			},
-			"depends_on": {
-				Expr: schema.ExprConstraints{
-					schema.TupleConsExpr{
-						Name: "set of references",
-						AnyElem: schema.ExprConstraints{
-							schema.TraversalExpr{OfScopeId: refscope.DataScope},
-							schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
-							schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+				"version": {
+					Expr:       schema.LiteralTypeOnly(cty.String),
+					IsOptional: true,
+					Description: lang.Markdown("Constraint to set the version of the module, e.g. `~> 1.0`." +
+						" Only applicable to modules in a module registry."),
+					CompletionHooks: lang.CompletionHooks{
+						{
+							Name: "CompleteRegistryModuleVersions",
 						},
 					},
 				},
-				IsOptional:  true,
-				Description: lang.Markdown("Set of references to hidden dependencies, e.g. other resources or data sources"),
+				"providers": {
+					Expr: schema.ExprConstraints{
+						schema.MapExpr{
+							Name: "map of provider references",
+							Elem: schema.ExprConstraints{
+								schema.TraversalExpr{OfScopeId: refscope.ProviderScope},
+							},
+						},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("Explicit mapping of providers which the module uses"),
+				},
+				"count": {
+					Expr: schema.ExprConstraints{
+						schema.TraversalExpr{OfType: cty.Number},
+						schema.LiteralTypeExpr{Type: cty.Number},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("Number of instances of this module, e.g. `3`"),
+				},
+				"for_each": {
+					Expr: schema.ExprConstraints{
+						schema.TraversalExpr{OfType: cty.Set(cty.DynamicPseudoType)},
+						schema.TraversalExpr{OfType: cty.Map(cty.DynamicPseudoType)},
+						schema.LiteralTypeExpr{Type: cty.Set(cty.DynamicPseudoType)},
+						schema.LiteralTypeExpr{Type: cty.Map(cty.DynamicPseudoType)},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("A set or a map where each item represents an instance of this module"),
+				},
+				"depends_on": {
+					Expr: schema.ExprConstraints{
+						schema.TupleConsExpr{
+							Name: "set of references",
+							AnyElem: schema.ExprConstraints{
+								schema.TraversalExpr{OfScopeId: refscope.DataScope},
+								schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
+								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+							},
+						},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("Set of references to hidden dependencies, e.g. other resources or data sources"),
+				},
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/0.13/provider_block.go
+++ b/internal/schema/0.13/provider_block.go
@@ -9,41 +9,43 @@ import (
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
 )
 
-var providerBlockSchema = &schema.BlockSchema{
-	Address: &schema.BlockAddrSchema{
-		Steps: []schema.AddrStep{
-			schema.LabelStep{Index: 0},
-			schema.AttrValueStep{Name: "alias", IsOptional: true},
-		},
-		FriendlyName: "provider",
-		ScopeId:      refscope.ProviderScope,
-		AsReference:  true,
-	},
-	SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Provider},
-	Labels: []*schema.LabelSchema{
-		{
-			Name:                   "name",
-			SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name, lang.TokenModifierDependent},
-			Description:            lang.PlainText("Provider Name"),
-			IsDepKey:               true,
-			Completable:            true,
-		},
-	},
-	Description: lang.PlainText("A provider block is used to specify a provider configuration"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"alias": {
-				Expr:        schema.LiteralTypeOnly(cty.String),
-				IsOptional:  true,
-				Description: lang.Markdown("Alias for using the same provider with different configurations for different resources, e.g. `eu-west`"),
+func providerBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.LabelStep{Index: 0},
+				schema.AttrValueStep{Name: "alias", IsOptional: true},
 			},
-			"version": {
-				Expr:         schema.LiteralTypeOnly(cty.String),
-				IsOptional:   true,
-				IsDeprecated: true,
-				Description: lang.Markdown("Specifies a version constraint for the provider. e.g. `~> 1.0`.\n" +
-					"**DEPRECATED:** Use `required_providers` block to manage provider version instead."),
+			FriendlyName: "provider",
+			ScopeId:      refscope.ProviderScope,
+			AsReference:  true,
+		},
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Provider},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name, lang.TokenModifierDependent},
+				Description:            lang.PlainText("Provider Name"),
+				IsDepKey:               true,
+				Completable:            true,
 			},
 		},
-	},
+		Description: lang.PlainText("A provider block is used to specify a provider configuration"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"alias": {
+					Expr:        schema.LiteralTypeOnly(cty.String),
+					IsOptional:  true,
+					Description: lang.Markdown("Alias for using the same provider with different configurations for different resources, e.g. `eu-west`"),
+				},
+				"version": {
+					Expr:         schema.LiteralTypeOnly(cty.String),
+					IsOptional:   true,
+					IsDeprecated: true,
+					Description: lang.Markdown("Specifies a version constraint for the provider. e.g. `~> 1.0`.\n" +
+						"**DEPRECATED:** Use `required_providers` block to manage provider version instead."),
+				},
+			},
+		},
+	}
 }

--- a/internal/schema/0.13/root.go
+++ b/internal/schema/0.13/root.go
@@ -12,8 +12,8 @@ var v0_13_4 = version.Must(version.NewVersion("0.13.4"))
 func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs := v012_mod.ModuleSchema(v)
 
-	bs.Blocks["module"] = moduleBlockSchema
-	bs.Blocks["provider"] = providerBlockSchema
+	bs.Blocks["module"] = moduleBlockSchema()
+	bs.Blocks["provider"] = providerBlockSchema()
 	bs.Blocks["terraform"] = terraformBlockSchema(v)
 	bs.Blocks["resource"].Body.Blocks["provisioner"].DependentBody = ProvisionerDependentBodies(v)
 

--- a/internal/schema/1.2/data.go
+++ b/internal/schema/1.2/data.go
@@ -5,16 +5,18 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 )
 
-var datasourceLifecycleBlock = &schema.BlockSchema{
-	Description: lang.Markdown("Lifecycle customizations to set validity conditions of the datasource"),
-	Body: &schema.BodySchema{
-		Blocks: map[string]*schema.BlockSchema{
-			"precondition": {
-				Body: conditionBody,
-			},
-			"postcondition": {
-				Body: conditionBody,
+func datasourceLifecycleBlock() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.Markdown("Lifecycle customizations to set validity conditions of the datasource"),
+		Body: &schema.BodySchema{
+			Blocks: map[string]*schema.BlockSchema{
+				"precondition": {
+					Body: conditionBody(),
+				},
+				"postcondition": {
+					Body: conditionBody(),
+				},
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/1.2/output.go
+++ b/internal/schema/1.2/output.go
@@ -5,13 +5,15 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 )
 
-var outputLifecycleBlock = &schema.BlockSchema{
-	Description: lang.Markdown("Lifecycle customizations, to set a validity condition of the output"),
-	Body: &schema.BodySchema{
-		Blocks: map[string]*schema.BlockSchema{
-			"precondition": {
-				Body: conditionBody,
+func outputLifecycleBlock() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.Markdown("Lifecycle customizations, to set a validity condition of the output"),
+		Body: &schema.BodySchema{
+			Blocks: map[string]*schema.BlockSchema{
+				"precondition": {
+					Body: conditionBody(),
+				},
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/1.2/resource.go
+++ b/internal/schema/1.2/resource.go
@@ -7,55 +7,57 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-var resourceLifecycleBlock = &schema.BlockSchema{
-	Description: lang.Markdown("Lifecycle customizations to change default resource behaviours during plan or apply"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"create_before_destroy": {
-				Expr:       schema.LiteralTypeOnly(cty.Bool),
-				IsOptional: true,
-				Description: lang.Markdown("Whether to reverse the default order of operations (destroy -> create) during apply " +
-					"when the resource requires replacement (cannot be updated in-place)"),
-			},
-			"prevent_destroy": {
-				Expr:       schema.LiteralTypeOnly(cty.Bool),
-				IsOptional: true,
-				Description: lang.Markdown("Whether to prevent accidental destruction of the resource and cause Terraform " +
-					"to reject with an error any plan that would destroy the resource"),
-			},
-			"ignore_changes": {
-				Expr: schema.ExprConstraints{
-					schema.TupleConsExpr{},
-					schema.KeywordExpr{
-						Keyword: "all",
-						Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
-							" and destroy the remote object but will never propose updates to it"),
-					},
+func resourceLifecycleBlock() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.Markdown("Lifecycle customizations to change default resource behaviours during plan or apply"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"create_before_destroy": {
+					Expr:       schema.LiteralTypeOnly(cty.Bool),
+					IsOptional: true,
+					Description: lang.Markdown("Whether to reverse the default order of operations (destroy -> create) during apply " +
+						"when the resource requires replacement (cannot be updated in-place)"),
 				},
-				IsOptional:  true,
-				Description: lang.Markdown("A set of fields (references) of which to ignore changes to, e.g. `tags`"),
-			},
-			"replace_triggered_by": {
-				Expr: schema.ExprConstraints{
-					schema.TupleConsExpr{
-						Name: "set of references",
-						AnyElem: schema.ExprConstraints{
-							schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+				"prevent_destroy": {
+					Expr:       schema.LiteralTypeOnly(cty.Bool),
+					IsOptional: true,
+					Description: lang.Markdown("Whether to prevent accidental destruction of the resource and cause Terraform " +
+						"to reject with an error any plan that would destroy the resource"),
+				},
+				"ignore_changes": {
+					Expr: schema.ExprConstraints{
+						schema.TupleConsExpr{},
+						schema.KeywordExpr{
+							Keyword: "all",
+							Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
+								" and destroy the remote object but will never propose updates to it"),
 						},
 					},
+					IsOptional:  true,
+					Description: lang.Markdown("A set of fields (references) of which to ignore changes to, e.g. `tags`"),
 				},
-				IsOptional: true,
-				Description: lang.Markdown("Set of references to any other resources which when changed cause " +
-					"this resource to be proposed for replacement"),
+				"replace_triggered_by": {
+					Expr: schema.ExprConstraints{
+						schema.TupleConsExpr{
+							Name: "set of references",
+							AnyElem: schema.ExprConstraints{
+								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
+							},
+						},
+					},
+					IsOptional: true,
+					Description: lang.Markdown("Set of references to any other resources which when changed cause " +
+						"this resource to be proposed for replacement"),
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"precondition": {
+					Body: conditionBody(),
+				},
+				"postcondition": {
+					Body: conditionBody(),
+				},
 			},
 		},
-		Blocks: map[string]*schema.BlockSchema{
-			"precondition": {
-				Body: conditionBody,
-			},
-			"postcondition": {
-				Body: conditionBody,
-			},
-		},
-	},
+	}
 }

--- a/internal/schema/1.2/root.go
+++ b/internal/schema/1.2/root.go
@@ -12,35 +12,37 @@ import (
 func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs := v1_1_mod.ModuleSchema(v)
 	bs.Blocks["data"].Body.Blocks = map[string]*schema.BlockSchema{
-		"lifecycle": datasourceLifecycleBlock,
+		"lifecycle": datasourceLifecycleBlock(),
 	}
-	bs.Blocks["resource"].Body.Blocks["lifecycle"] = resourceLifecycleBlock
+	bs.Blocks["resource"].Body.Blocks["lifecycle"] = resourceLifecycleBlock()
 	bs.Blocks["output"].Body.Blocks = map[string]*schema.BlockSchema{
-		"lifecycle": outputLifecycleBlock,
+		"lifecycle": outputLifecycleBlock(),
 	}
 
 	return bs
 }
 
-var conditionBody = &schema.BodySchema{
-	Attributes: map[string]*schema.AttributeSchema{
-		"condition": {
-			Expr: schema.ExprConstraints{
-				schema.TraversalExpr{OfType: cty.Bool},
-				schema.LiteralTypeExpr{Type: cty.Bool},
+func conditionBody() *schema.BodySchema {
+	return &schema.BodySchema{
+		Attributes: map[string]*schema.AttributeSchema{
+			"condition": {
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfType: cty.Bool},
+					schema.LiteralTypeExpr{Type: cty.Bool},
+				},
+				IsRequired: true,
+				Description: lang.Markdown("Condition, a boolean expression that should return `true` " +
+					"if the intended assumption or guarantee is fulfilled or `false` if it is not."),
 			},
-			IsRequired: true,
-			Description: lang.Markdown("Condition, a boolean expression that should return `true` " +
-				"if the intended assumption or guarantee is fulfilled or `false` if it is not."),
-		},
-		"error_message": {
-			Expr: schema.ExprConstraints{
-				schema.TraversalExpr{OfType: cty.String},
-				schema.LiteralTypeExpr{Type: cty.String},
+			"error_message": {
+				Expr: schema.ExprConstraints{
+					schema.TraversalExpr{OfType: cty.String},
+					schema.LiteralTypeExpr{Type: cty.String},
+				},
+				IsRequired: true,
+				Description: lang.Markdown("Error message to return if the `condition` isn't met " +
+					"(evaluates to `false`)."),
 			},
-			IsRequired: true,
-			Description: lang.Markdown("Error message to return if the `condition` isn't met " +
-				"(evaluates to `false`)."),
 		},
-	},
+	}
 }


### PR DESCRIPTION
This PR fixes the root cause for a race condition we encountered during the upgrade to Go 1.19 in the Terraform language server: https://github.com/hashicorp/terraform-ls/runs/7977447318?check_suite_focus=true

Parts of the core schema were defined as static pointers on the package level, making them shared between different instances of the core schema.

Enabling `[ ] Hide whitespace` makes the PR easier to review.