### PR TITLE
fix: account for exact match of resource name

### DIFF
--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -117,7 +117,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 
 					// No explicit association is required
 					// if the resource prefix matches provider name
-					if strings.HasPrefix(rName, localRef.LocalName+"_") {
+					if typeBelongsToProvider(rName, localRef) {
 						depKeys := schema.DependencyKeys{
 							Labels: []schema.LabelDependent{
 								{Index: 0, Value: rName},
@@ -159,7 +159,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 
 					// No explicit association is required
 					// if the resource prefix matches provider name
-					if strings.HasPrefix(dsName, localRef.LocalName+"_") {
+					if typeBelongsToProvider(dsName, localRef) {
 						depKeys := schema.DependencyKeys{
 							Labels: []schema.LabelDependent{
 								{Index: 0, Value: dsName},
@@ -325,6 +325,15 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 		}
 	}
 	return mergedSchema, nil
+}
+
+// typeBelongsToProvider returns true if the given type
+// (resource or data source) name belongs to a particular provider.
+//
+// This reflects internal implementation in Terraform at
+// https://github.com/hashicorp/terraform/blob/488bbd80/internal/addrs/resource.go#L68-L77
+func typeBelongsToProvider(typeName string, pRef tfmod.ProviderRef) bool {
+	return typeName == pRef.LocalName || strings.HasPrefix(typeName, pRef.LocalName+"_")
 }
 
 func variableDependentBody(vars map[string]tfmod.Variable) map[schema.SchemaKey]*schema.BodySchema {


### PR DESCRIPTION
## Before
![Screenshot 2022-09-13 at 11 01 42](https://user-images.githubusercontent.com/287584/189873178-ebf7e5ed-d429-4582-8d80-c344d4b8a270.png)

## After

![Screenshot 2022-09-13 at 10 59 56](https://user-images.githubusercontent.com/287584/189873221-55609f8e-4dd0-4f0e-8c5c-011f62126a25.png)
![Screenshot 2022-09-13 at 11 00 28](https://user-images.githubusercontent.com/287584/189873223-2770e43e-2e66-4120-89ce-08d1d298dc83.png)
