### PR TITLE
Turn resource lifecycle block into a func

### DIFF
--- a/internal/schema/0.12/resource_block.go
+++ b/internal/schema/0.12/resource_block.go
@@ -71,7 +71,7 @@ func resourceBlockSchema(v *version.Version) *schema.BlockSchema {
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{
-				"lifecycle":   lifecycleBlock,
+				"lifecycle":   lifecycleBlock(),
 				"connection":  connectionBlock(v),
 				"provisioner": provisionerBlock(v),
 			},
@@ -81,34 +81,36 @@ func resourceBlockSchema(v *version.Version) *schema.BlockSchema {
 	return bs
 }
 
-var lifecycleBlock = &schema.BlockSchema{
-	Description: lang.Markdown("Lifecycle customizations to change default resource behaviours during apply"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"create_before_destroy": {
-				Expr:       schema.LiteralTypeOnly(cty.Bool),
-				IsOptional: true,
-				Description: lang.Markdown("Whether to reverse the default order of operations (destroy -> create) during apply " +
-					"when the resource requires replacement (cannot be updated in-place)"),
-			},
-			"prevent_destroy": {
-				Expr:       schema.LiteralTypeOnly(cty.Bool),
-				IsOptional: true,
-				Description: lang.Markdown("Whether to prevent accidental destruction of the resource and cause Terraform " +
-					"to reject with an error any plan that would destroy the resource"),
-			},
-			"ignore_changes": {
-				Expr: schema.ExprConstraints{
-					schema.TupleConsExpr{},
-					schema.KeywordExpr{
-						Keyword: "all",
-						Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
-							" and destroy the remote object but will never propose updates to it"),
-					},
+func lifecycleBlock() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.Markdown("Lifecycle customizations to change default resource behaviours during apply"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"create_before_destroy": {
+					Expr:       schema.LiteralTypeOnly(cty.Bool),
+					IsOptional: true,
+					Description: lang.Markdown("Whether to reverse the default order of operations (destroy -> create) during apply " +
+						"when the resource requires replacement (cannot be updated in-place)"),
 				},
-				IsOptional:  true,
-				Description: lang.Markdown("A set of fields (references) of which to ignore changes to, e.g. `tags`"),
+				"prevent_destroy": {
+					Expr:       schema.LiteralTypeOnly(cty.Bool),
+					IsOptional: true,
+					Description: lang.Markdown("Whether to prevent accidental destruction of the resource and cause Terraform " +
+						"to reject with an error any plan that would destroy the resource"),
+				},
+				"ignore_changes": {
+					Expr: schema.ExprConstraints{
+						schema.TupleConsExpr{},
+						schema.KeywordExpr{
+							Keyword: "all",
+							Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
+								" and destroy the remote object but will never propose updates to it"),
+						},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("A set of fields (references) of which to ignore changes to, e.g. `tags`"),
+				},
 			},
 		},
-	},
+	}
 }


### PR DESCRIPTION
I missed this during https://github.com/hashicorp/terraform-schema/pull/137.

Enabling `[ ] Hide whitespace` makes the PR easier to review.