### PR TITLE
Add support for dynamic block extensions

### DIFF
--- a/internal/schema/0.12/data_block.go
+++ b/internal/schema/0.12/data_block.go
@@ -43,8 +43,9 @@ func datasourceBlockSchema(v *version.Version) *schema.BlockSchema {
 			"Terraform module, but has no significance outside of the scope of a module."),
 		Body: &schema.BodySchema{
 			Extensions: &schema.BodyExtensions{
-				Count:   true,
-				ForEach: true, // for_each was introduced in 0.12.6, but for simplicity we report it for all 0.12+
+				Count:         true,
+				ForEach:       true, // for_each was introduced in 0.12.6, but for simplicity we report it for all 0.12+
+				DynamicBlocks: true,
 			},
 			Attributes: map[string]*schema.AttributeSchema{
 				"provider": {

--- a/internal/schema/0.12/provider_block.go
+++ b/internal/schema/0.12/provider_block.go
@@ -32,6 +32,9 @@ func providerBlockSchema(v *version.Version) *schema.BlockSchema {
 		},
 		Description: lang.PlainText("A provider block is used to specify a provider configuration"),
 		Body: &schema.BodySchema{
+			Extensions: &schema.BodyExtensions{
+				DynamicBlocks: true,
+			},
 			Attributes: map[string]*schema.AttributeSchema{
 				"alias": {
 					Expr:        schema.LiteralTypeOnly(cty.String),

--- a/internal/schema/0.12/resource_block.go
+++ b/internal/schema/0.12/resource_block.go
@@ -43,8 +43,9 @@ func resourceBlockSchema(v *version.Version) *schema.BlockSchema {
 			"outside of the scope of a module."),
 		Body: &schema.BodySchema{
 			Extensions: &schema.BodyExtensions{
-				Count:   true,
-				ForEach: true, // for_each was introduced in 0.12.6, but for simplicity we report it for all 0.12+
+				Count:         true,
+				ForEach:       true, // for_each was introduced in 0.12.6, but for simplicity we report it for all 0.12+
+				DynamicBlocks: true,
 			},
 			Attributes: map[string]*schema.AttributeSchema{
 				"provider": {


### PR DESCRIPTION
This adds support for a dynamic "meta" block within resource data, provider ~and provisioner~ block.

For posterity, [Changelog](https://github.com/hashicorp/terraform/blob/v0.12.0/CHANGELOG.md#0120-may-22-2019) confirms that `dynamic` blocks were introduced in `v0.12.0`.