### PR TITLE
Add dynamic to provisioner and provider block

### DIFF
--- a/internal/schema/0.12/provisioner_block.go
+++ b/internal/schema/0.12/provisioner_block.go
@@ -23,7 +23,8 @@ func provisionerBlock(v *version.Version) *schema.BlockSchema {
 		},
 		Body: &schema.BodySchema{
 			Extensions: &schema.BodyExtensions{
-				SelfRefs: true,
+				DynamicBlocks: true,
+				SelfRefs:      true,
 			},
 			HoverURL: "https://www.terraform.io/docs/language/resources/provisioners/syntax.html",
 			Attributes: map[string]*schema.AttributeSchema{

--- a/internal/schema/0.13/provider_block.go
+++ b/internal/schema/0.13/provider_block.go
@@ -32,6 +32,9 @@ func providerBlockSchema() *schema.BlockSchema {
 		},
 		Description: lang.PlainText("A provider block is used to specify a provider configuration"),
 		Body: &schema.BodySchema{
+			Extensions: &schema.BodyExtensions{
+				DynamicBlocks: true,
+			},
 			Attributes: map[string]*schema.AttributeSchema{
 				"alias": {
 					Expr:        schema.LiteralTypeOnly(cty.String),


### PR DESCRIPTION
We missed adding the dynamic block body extensions to those two blocks.

https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks
> You can dynamically construct repeatable nested blocks like setting using a special dynamic block type, which is supported inside `resource`, `data`, `provider`, and `provisioner` blocks:

