### PR TITLE
internal/schema: Replace `TupleConsExpr` with `SetExpr`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/hcl-lang v0.0.0-20221130131410-9f07ba77f1d7
+	github.com/hashicorp/hcl-lang v0.0.0-20221213144118-12ed55dc4488
 	github.com/hashicorp/hcl/v2 v2.15.0
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/hcl-lang v0.0.0-20221130131410-9f07ba77f1d7 h1:RGomyhrMBFUmenD2BW44yzes99+50RgLthjoiX673+o=
-github.com/hashicorp/hcl-lang v0.0.0-20221130131410-9f07ba77f1d7/go.mod h1:it6xaAkaNpJd9WicHQmPMb88VKpp+S2PwB+5GPOuVYc=
+github.com/hashicorp/hcl-lang v0.0.0-20221213144118-12ed55dc4488 h1:M84SjUpmvXQfz2MnI/G3XlBZ2Vv44V16t6bj5zja4DY=
+github.com/hashicorp/hcl-lang v0.0.0-20221213144118-12ed55dc4488/go.mod h1:NR4/o2Ur8BItrAtCw6dH5xVpPitcr0D2epIoibezXuU=
 github.com/hashicorp/hcl/v2 v2.15.0 h1:CPDXO6+uORPjKflkWCCwoWc9uRp+zSIPcCQ+BrxV7m8=
 github.com/hashicorp/hcl/v2 v2.15.0/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e17dKDpqV7s=

--- a/internal/schema/0.12/data_block.go
+++ b/internal/schema/0.12/data_block.go
@@ -59,9 +59,8 @@ func datasourceBlockSchema(v *version.Version) *schema.BlockSchema {
 				},
 				"depends_on": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of references",
-							AnyElem: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.ExprConstraints{
 								schema.TraversalExpr{OfScopeId: refscope.DataScope},
 								schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
 								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},

--- a/internal/schema/0.12/output_block.go
+++ b/internal/schema/0.12/output_block.go
@@ -50,9 +50,8 @@ func outputBlockSchema() *schema.BlockSchema {
 				},
 				"depends_on": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of references",
-							AnyElem: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.ExprConstraints{
 								schema.TraversalExpr{OfScopeId: refscope.DataScope},
 								schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
 								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},

--- a/internal/schema/0.12/resource_block.go
+++ b/internal/schema/0.12/resource_block.go
@@ -59,9 +59,8 @@ func resourceBlockSchema(v *version.Version) *schema.BlockSchema {
 				},
 				"depends_on": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of references",
-							AnyElem: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.ExprConstraints{
 								schema.TraversalExpr{OfScopeId: refscope.DataScope},
 								schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
 								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
@@ -102,7 +101,7 @@ func lifecycleBlock() *schema.BlockSchema {
 				},
 				"ignore_changes": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{},
+						schema.SetExpr{},
 						schema.KeywordExpr{
 							Keyword: "all",
 							Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +

--- a/internal/schema/0.12/terraform_block.go
+++ b/internal/schema/0.12/terraform_block.go
@@ -64,12 +64,11 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 	}
 
 	if v.GreaterThanOrEqual(v0_12_18) {
-		experiments := schema.TupleConsExpr{
-			AnyElem: schema.ExprConstraints{},
-			Name:    "set of features",
+		experiments := schema.SetExpr{
+			Elem: schema.ExprConstraints{},
 		}
 		if v.GreaterThanOrEqual(v0_12_20) {
-			experiments.AnyElem = append(experiments.AnyElem, schema.KeywordExpr{
+			experiments.Elem = append(experiments.Elem, schema.KeywordExpr{
 				Keyword: "variable_validation",
 				Name:    "feature",
 			})

--- a/internal/schema/0.13/module_block.go
+++ b/internal/schema/0.13/module_block.go
@@ -78,9 +78,8 @@ func moduleBlockSchema() *schema.BlockSchema {
 				},
 				"depends_on": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of references",
-							AnyElem: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.ExprConstraints{
 								schema.TraversalExpr{OfScopeId: refscope.DataScope},
 								schema.TraversalExpr{OfScopeId: refscope.ModuleScope},
 								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},

--- a/internal/schema/0.13/terraform_block.go
+++ b/internal/schema/0.13/terraform_block.go
@@ -23,9 +23,7 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 				},
 				"experiments": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of features",
-						},
+						schema.SetExpr{},
 					},
 					IsOptional:  true,
 					Description: lang.Markdown("A set of experimental language features to enable"),

--- a/internal/schema/0.14/terraform.go
+++ b/internal/schema/0.14/terraform.go
@@ -24,9 +24,8 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 				},
 				"experiments": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of features",
-							AnyElem: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.ExprConstraints{
 								schema.KeywordExpr{
 									Keyword: "module_variable_optional_attrs",
 									Name:    "feature",

--- a/internal/schema/1.2/resource.go
+++ b/internal/schema/1.2/resource.go
@@ -26,7 +26,7 @@ func resourceLifecycleBlock() *schema.BlockSchema {
 				},
 				"ignore_changes": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{},
+						schema.SetExpr{},
 						schema.KeywordExpr{
 							Keyword: "all",
 							Description: lang.Markdown("Ignore all attributes, which means that Terraform can create" +
@@ -38,9 +38,8 @@ func resourceLifecycleBlock() *schema.BlockSchema {
 				},
 				"replace_triggered_by": {
 					Expr: schema.ExprConstraints{
-						schema.TupleConsExpr{
-							Name: "set of references",
-							AnyElem: schema.ExprConstraints{
+						schema.SetExpr{
+							Elem: schema.ExprConstraints{
 								schema.TraversalExpr{OfScopeId: refscope.ResourceScope},
 							},
 						},


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/496

The attributes in question will never be treated as data, so the data type doesn't really matter as much in this context. The main effect is hints in the completion and hover data.

Set seems most appropriate of all options (list, set, tuple), given that every element is of the same type (which rules out tuple) and order of elements doesn't matter (which rules out list).

--- 

The attributes in question will never be treated as data, so the data type doesn't really matter as much in this context. The main effect is hints in the completion and hover data.

Set seems most appropriate of all options (list, set, tuple), given that every element is of the same type (which rules out tuple) and order of elements doesn't matter (which rules out list).

--- 

## UX Impact

(This implies https://github.com/hashicorp/hcl-lang/pull/175 also in effect)

This has some relatively minor side effects in the completion and hover UX. One is mostly positive (experiments) and others are still okay (displaying singular instead of plural).

We can discuss whether the singular/plural thing is worth addressing and what the best version is there, but the PR is mainly meaning to solve the bug which is mis-rendering multiple constraints under collection types.

Also I am not sure if using more concrete description of a type, such as `experiment` is actually more helpful than just `keyword`. 🤷🏻 

### Before

![Screenshot 2022-12-12 at 10 16 24](https://user-images.githubusercontent.com/287584/207021234-0bf0fc95-02de-4dc8-a10d-8e12de50331c.png)
![Screenshot 2022-12-12 at 10 16 45](https://user-images.githubusercontent.com/287584/207021241-3318a0cc-85ba-4d67-b110-8c6ffd4a0cee.png)
![Screenshot 2022-12-12 at 10 16 54](https://user-images.githubusercontent.com/287584/207021243-ecdc3e9c-a532-4f2a-a330-34e482745f53.png)
![Screenshot 2022-12-12 at 10 17 06](https://user-images.githubusercontent.com/287584/207021245-584fcfb1-bebe-4970-970e-0b9c733324fc.png)
![Screenshot 2022-12-12 at 10 18 12](https://user-images.githubusercontent.com/287584/207021248-8466ece1-e6f3-4e46-a76f-9aa846c0a1a5.png)

### After

![Screenshot 2022-12-12 at 10 26 23](https://user-images.githubusercontent.com/287584/207022663-a483c73b-16ca-47ba-80eb-627bc15b444c.png)
![Screenshot 2022-12-12 at 10 26 41](https://user-images.githubusercontent.com/287584/207022666-1bfe76f4-a830-459a-9282-9271b4b3eae7.png)
![Screenshot 2022-12-12 at 10 26 52](https://user-images.githubusercontent.com/287584/207022669-e567672a-f027-4dac-8dd7-d1ba2b935760.png)
![Screenshot 2022-12-12 at 10 26 59](https://user-images.githubusercontent.com/287584/207022670-15cd0de8-08f5-4322-b86d-4c66ad747a9a.png)
![Screenshot 2022-12-12 at 10 27 36](https://user-images.githubusercontent.com/287584/207022674-da2c199d-1dfc-4db4-b4ea-c03347ebaa5f.png)
