### PR TITLE
Leverage TypeConstraintWithDefaults when parsing default values

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform-schema/backend"
@@ -803,6 +804,42 @@ variable "name" {
 					"name": {
 						Type:         cty.DynamicPseudoType,
 						DefaultValue: cty.EmptyObjectVal,
+					},
+				},
+				Outputs:     map[string]module.Output{},
+				Filenames:   []string{"test.tf"},
+				ModuleCalls: map[string]module.DeclaredModuleCall{},
+			},
+			nil,
+		},
+		{
+			"variables with optional type values",
+			`
+variable "name" {
+  type = object({
+		foo = optional(string, "food")
+		bar = optional(number)
+	})
+}`,
+			&module.Meta{
+				Path:                 path,
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables: map[string]module.Variable{
+					"name": {
+						Type: cty.Object(map[string]cty.Type{
+							"foo": cty.String,
+							"bar": cty.Number,
+						}),
+						TypeDefaults: &typeexpr.Defaults{
+							Type: cty.Object(map[string]cty.Type{
+								"foo": cty.String,
+								"bar": cty.Number,
+							}),
+							DefaultValues: map[string]cty.Value{
+								"foo": cty.StringVal("food"),
+							},
+						},
 					},
 				},
 				Outputs:     map[string]module.Output{},

--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -817,9 +817,9 @@ variable "name" {
 			`
 variable "name" {
   type = object({
-		foo = optional(string, "food")
-		bar = optional(number)
-	})
+    foo = optional(string, "food")
+    bar = optional(number)
+  })
 }`,
 			&module.Meta{
 				Path:                 path,

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -216,7 +216,6 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 			varType := cty.DynamicPseudoType
 			var defaults *typeexpr.Defaults
 			if attr, defined := content.Attributes["type"]; defined {
-				// varType, valDiags = typeexpr.TypeConstraint(attr.Expr)
 				varType, defaults, valDiags = typeexpr.TypeConstraintWithDefaults(attr.Expr)
 				diags = append(diags, valDiags...)
 			}

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -214,8 +214,10 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 				diags = append(diags, valDiags...)
 			}
 			varType := cty.DynamicPseudoType
+			var defaults *typeexpr.Defaults
 			if attr, defined := content.Attributes["type"]; defined {
-				varType, valDiags = typeexpr.TypeConstraint(attr.Expr)
+				// varType, valDiags = typeexpr.TypeConstraint(attr.Expr)
+				varType, defaults, valDiags = typeexpr.TypeConstraintWithDefaults(attr.Expr)
 				diags = append(diags, valDiags...)
 			}
 			if attr, defined := content.Attributes["sensitive"]; defined {
@@ -239,6 +241,7 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 							val = cty.DynamicVal
 						}
 					}
+
 					defaultValue = val
 				}
 			}
@@ -247,6 +250,7 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 				Description:  description,
 				IsSensitive:  isSensitive,
 				DefaultValue: defaultValue,
+				TypeDefaults: defaults,
 			}
 		case "output":
 			content, _, contentDiags := block.Body.PartialContent(outputSchema)

--- a/module/variable.go
+++ b/module/variable.go
@@ -17,5 +17,10 @@ type Variable struct {
 	// and is decodable without errors, else cty.NilVal
 	DefaultValue cty.Value
 
+	// TypeDefaults represents any default values for optional object
+	// attributes assuming Type is of cty.Object and has defaults.
+	//
+	// Any relationships between DefaultValue & TypeDefaults are left
+	// for downstream to deal with using e.g. TypeDefaults.Apply().
 	TypeDefaults *typeexpr.Defaults
 }

--- a/module/variable.go
+++ b/module/variable.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -15,4 +16,6 @@ type Variable struct {
 	// DefaultValue represents default value if one is defined
 	// and is decodable without errors, else cty.NilVal
 	DefaultValue cty.Value
+
+	TypeDefaults *typeexpr.Defaults
 }


### PR DESCRIPTION
Previously we would ignore any default values when parsing types. This change now stores default values for attributes when parsing types. This will be used in the future when implementing more detailed nested expressions.
