### PR TITLE
earlydecoder: Avoid producing diagnostics for unknown blocks

### DIFF
--- a/earlydecoder/backend.go
+++ b/earlydecoder/backend.go
@@ -32,18 +32,18 @@ func decodeBackendsBlock(block *hcl.Block) (backend.BackendData, hcl.Diagnostics
 }
 
 func decodeCloudBlock(block *hcl.Block) (*backend.Cloud, hcl.Diagnostics) {
-	attrs, diags := block.Body.JustAttributes()
+	attrs, _ := block.Body.JustAttributes()
+	// Ignore diagnostics which may complain about unknown blocks
 
 	// https://developer.hashicorp.com/terraform/language/settings/terraform-cloud#usage-example
 	// Required for Terraform Enterprise
 	// Defaults to app.terraform.io for Terraform Cloud
 	if attr, ok := attrs["hostname"]; ok {
 		val, vDiags := attr.Expr.Value(nil)
-		diags = append(diags, vDiags...)
 		if val.IsWhollyKnown() && val.Type() == cty.String {
 			return &backend.Cloud{
 				Hostname: val.AsString(),
-			}, diags
+			}, vDiags
 		}
 	}
 

--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1046,6 +1046,32 @@ terraform {
 			},
 			nil,
 		},
+		{
+			"additional block",
+			`
+terraform {
+	cloud {
+		hostname = "foo.com"
+		workspaces {
+			tags = ["app"]
+		}
+	}
+}`,
+			&module.Meta{
+				Path:    path,
+				Backend: nil,
+				Cloud: &backend.Cloud{
+					Hostname: "foo.com",
+				},
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls:          map[string]module.DeclaredModuleCall{},
+			},
+			nil,
+		},
 	}
 
 	runTestCases(testCases, t, path)


### PR DESCRIPTION
While investigating traces from the Terraform LS, we noticed a diagnostic which was irrelevant, given the design, context and role of the `earlydecoder`:

<img width="1333" alt="Screenshot 2023-07-31 at 12 18 56" src="https://github.com/hashicorp/terraform-schema/assets/287584/15533f80-3146-46a8-941a-7c32d41af6cb">

The earlydecoder is meant to be able to deal with as many Terraform versions as possible and it shouldn't try to accurately list all known attributes and blocks as that would do the opposite and it would always be inevitably behind. Therefore, it has to ignore unknown blocks.

This doesn't affect the user in any way, since we don't surface this diagnostic to them, but it just creates unnecessary noise in tracing data.