### PR TITLE
fix: Include backend in dependent bodies to avoid false negatives

### DIFF
--- a/schema/schema_merge_remote_state_ds.go
+++ b/schema/schema_merge_remote_state_ds.go
@@ -51,6 +51,11 @@ func (sm *SchemaMerger) dependentBodyForRemoteStateDataSource(providerAddr lang.
 
 		dsSchema := &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
+				"backend": {
+					Constraint:             backends.BackendTypesAsOneOfConstraint(sm.terraformVersion),
+					IsRequired:             true,
+					SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+				},
 				"config": {
 					Constraint: objConstraint,
 					IsOptional: true,

--- a/schema/schema_merge_v012_test.go
+++ b/schema/schema_merge_v012_test.go
@@ -1339,94 +1339,184 @@ var expectedMergedSchema_v012 = &schema.BodySchema{
 					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"artifactory"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["artifactory"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["artifactory"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"artifactory"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["artifactory"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["artifactory"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"atlas"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["atlas"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["atlas"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"atlas"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["atlas"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["atlas"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azure"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azure"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azure"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azure"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azure"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azure"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azurerm"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azurerm"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azurerm"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azurerm"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azurerm"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["azurerm"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"consul"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["consul"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["consul"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"consul"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["consul"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["consul"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcd"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcd"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcd"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcd"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcd"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcd"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcdv3"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcdv3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcdv3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcdv3"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcdv3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["etcdv3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"gcs"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["gcs"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["gcs"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"gcs"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["gcs"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["gcs"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"http"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["http"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["http"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"http"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["http"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["http"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"local"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["local"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["local"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"local"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["local"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["local"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"manta"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["manta"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["manta"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"manta"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["manta"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["manta"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"pg"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["pg"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["pg"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"pg"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["pg"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["pg"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"remote"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["remote"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["remote"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"remote"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["remote"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["remote"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"s3"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["s3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["s3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"s3"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["s3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["s3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"swift"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["swift"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["swift"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"swift"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["swift"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_12_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_12_0)["swift"]},
+					},
 				},
 			},
 		},

--- a/schema/schema_merge_v013_test.go
+++ b/schema/schema_merge_v013_test.go
@@ -1794,112 +1794,220 @@ var expectedMergedSchema_v013 = &schema.BodySchema{
 					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"artifactory"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["artifactory"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["artifactory"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"artifactory"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["artifactory"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["artifactory"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"atlas"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["atlas"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["atlas"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"atlas"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["atlas"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["atlas"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azure"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azure"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azure"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azure"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azure"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azure"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azurerm"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azurerm"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azurerm"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"azurerm"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azurerm"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["azurerm"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"consul"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["consul"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["consul"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"consul"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["consul"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["consul"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"cos"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["cos"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["cos"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"cos"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["cos"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["cos"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcd"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcd"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcd"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcd"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcd"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcd"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcdv3"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcdv3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcdv3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"etcdv3"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcdv3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["etcdv3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"gcs"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["gcs"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["gcs"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"gcs"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["gcs"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["gcs"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"http"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["http"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["http"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"http"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["http"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["http"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"kubernetes"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["kubernetes"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["kubernetes"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"kubernetes"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["kubernetes"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["kubernetes"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"local"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["local"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["local"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"local"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["local"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["local"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"manta"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["manta"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["manta"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"manta"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["manta"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["manta"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"oss"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["oss"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["oss"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"oss"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["oss"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["oss"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"pg"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["pg"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["pg"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"pg"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["pg"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["pg"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"remote"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["remote"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["remote"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"remote"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["remote"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["remote"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"s3"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["s3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["s3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"s3"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["s3"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["s3"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"swift"}},{"name":"provider","expr":{"addr":"terraform"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["swift"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["swift"]},
+					},
 				},
 				`{"labels":[{"index":0,"value":"terraform_remote_state"}],"attrs":[{"name":"backend","expr":{"static":"swift"}}]}`: {
-					Attributes: map[string]*schema.AttributeSchema{"config": {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["swift"]}},
+					Attributes: map[string]*schema.AttributeSchema{
+						"backend": {IsRequired: true, Constraint: backends.BackendTypesAsOneOfConstraint(v0_13_0), SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent}},
+						"config":  {IsOptional: true, Constraint: backends.ConfigsAsObjectConstraint(v0_13_0)["swift"]},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Context

A bug was discovered as part of testing https://github.com/hashicorp/terraform-ls/pull/1368 - see below.

![CleanShot 2023-09-01 at 17 03 14](https://github.com/hashicorp/terraform-schema/assets/287584/f90fa653-4e34-4083-8fcd-a15e6b5fb64a)

--- 

The assumption I made in the beginning of investigating this bug - which is likely the same assumption made while the bug was introduced in the first place - that the `backend` attribute is part of a core schema which we'd end up keeping after merge, just like we keep `depends_on` and similar ones.

However, the `terraform_remote_state` data source is a bit different in that the "merge hierarchy" is much flatter, where the "non-backend" body is on the same level as the "backend-specific" body, so no merging can ever happen between the two:

```go
// data block
DependentBody: {
     "{\"labels\":[{\"index\":0,\"value\":\"terraform_remote_state\"}]}": &schema.BodySchema{
                                Attributes: {
                                    "backend": &schema.AttributeSchema{
                                        IsRequired:   true,
                                        Constraint:   schema.OneOf{
                                            schema.LiteralValue{
                                                Value:        cty.StringVal("azurerm"),
                                                IsDeprecated: false,
                                                Description:  lang.MarkupContent{Value:"Azure Blob Storage", Kind:0x2},
                                            },
// ...
                                            schema.LiteralValue{
                                                Value:        cty.StringVal("s3"),
                                                IsDeprecated: false,
                                                Description:  lang.MarkupContent{Value:"Amazon S3 (with locking via DynamoDB)", Kind:0x2},
                                            },
                                        },
                                        IsDepKey:               true,
                                        SemanticTokenModifiers: {"hcl-dependent"},
                                    },
     "{\"labels\":[{\"index\":0,\"value\":\"terraform_remote_state\"}],\"attrs\":[{\"name\":\"backend\",\"expr\":{\"static\":\"s3\"}}]}": &schema.BodySchema{
                    Blocks:     {},
                    Attributes: {
// ... (no backend attribute here)
```

## Implementation Notes

I initially thought we could just set the `backend` Constraint to the given `schema.LiteralValue{}` for each backend. While this _would_ address the validation problem, it would also make it much more difficult to solve https://github.com/hashicorp/terraform-ls/issues/1284 as we wouldn't have access to all the other backends and their details at completion time, when the merging has already taken place (because `backend` has matching value).