### PR TITLE
go.mod: Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-schema
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
This reflects upstream changes as described in https://github.com/golang/go/issues/62278 and unblocks dependabot which currently cannot run.

<img width="910" alt="Screenshot 2023-09-06 at 07 21 07" src="https://github.com/hashicorp/hcl-lang/assets/287584/e26c0d58-2c54-450d-8939-e2cbe4ec18ca">

An alternative fix would be to add `toolchain 1.21.0` but given that we don't need different version for compatibility and toolchain I think it's easier to just update the `go` directive for now.

See also https://github.com/dependabot/dependabot-core/issues/7895
