### PR TITLE
Add `nullable` to `variable` blocks for 1.1+

### DIFF
--- a/internal/schema/0.14/root.go
+++ b/internal/schema/0.14/root.go
@@ -13,7 +13,7 @@ import (
 func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs := v013_mod.ModuleSchema(v)
 
-	bs.Blocks["variable"] = variableBlockSchema
+	bs.Blocks["variable"] = variableBlockSchema()
 	bs.Blocks["terraform"] = terraformBlockSchema(v)
 	bs.Blocks["resource"].Body.Blocks["provisioner"].DependentBody = ProvisionerDependentBodies
 

--- a/internal/schema/0.14/variable_block.go
+++ b/internal/schema/0.14/variable_block.go
@@ -12,68 +12,70 @@ import (
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
 )
 
-var variableBlockSchema = &schema.BlockSchema{
-	Address: &schema.BlockAddrSchema{
-		Steps: []schema.AddrStep{
-			schema.StaticStep{Name: "var"},
-			schema.LabelStep{Index: 0},
-		},
-		FriendlyName: "variable",
-		ScopeId:      refscope.VariableScope,
-		AsReference:  true,
-		AsTypeOf: &schema.BlockAsTypeOf{
-			AttributeExpr:  "type",
-			AttributeValue: "default",
-		},
-	},
-	SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variable},
-	Labels: []*schema.LabelSchema{
-		{
-			Name:                   "name",
-			SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
-			Description:            lang.PlainText("Variable Name"),
-		},
-	},
-	Description: lang.Markdown("Input variable allowing users to customizate aspects of the configuration when used directly " +
-		"(e.g. via CLI, `tfvars` file or via environment variables), or as a module (via `module` arguments)"),
-	Body: &schema.BodySchema{
-		Attributes: map[string]*schema.AttributeSchema{
-			"description": {
-				Constraint:  schema.LiteralType{Type: cty.String},
-				IsOptional:  true,
-				Description: lang.Markdown("Description to document the purpose of the variable and what value is expected"),
+func variableBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "var"},
+				schema.LabelStep{Index: 0},
 			},
-			"type": {
-				Constraint:  schema.TypeDeclaration{},
-				IsOptional:  true,
-				Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
-			},
-			"sensitive": {
-				Constraint:  schema.LiteralType{Type: cty.Bool},
-				IsOptional:  true,
-				Description: lang.Markdown("Whether the variable contains sensitive material and should be hidden in the UI"),
+			FriendlyName: "variable",
+			ScopeId:      refscope.VariableScope,
+			AsReference:  true,
+			AsTypeOf: &schema.BlockAsTypeOf{
+				AttributeExpr:  "type",
+				AttributeValue: "default",
 			},
 		},
-		Blocks: map[string]*schema.BlockSchema{
-			"validation": {
-				Description: lang.Markdown("Custom validation rule to restrict what value is expected for the variable"),
-				Body: &schema.BodySchema{
-					Attributes: map[string]*schema.AttributeSchema{
-						"condition": {
-							Constraint: schema.LiteralType{Type: cty.Bool},
-							IsRequired: true,
-							Description: lang.Markdown("Condition under which a variable value is valid, " +
-								"e.g. `length(var.example) >= 4` enforces minimum of 4 characters"),
-						},
-						"error_message": {
-							Constraint: schema.LiteralType{Type: cty.String},
-							IsRequired: true,
-							Description: lang.Markdown("Error message to present when the variable is considered invalid, " +
-								"i.e. when `condition` evaluates to `false`"),
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variable},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Variable Name"),
+			},
+		},
+		Description: lang.Markdown("Input variable allowing users to customizate aspects of the configuration when used directly " +
+			"(e.g. via CLI, `tfvars` file or via environment variables), or as a module (via `module` arguments)"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"description": {
+					Constraint:  schema.LiteralType{Type: cty.String},
+					IsOptional:  true,
+					Description: lang.Markdown("Description to document the purpose of the variable and what value is expected"),
+				},
+				"type": {
+					Constraint:  schema.TypeDeclaration{},
+					IsOptional:  true,
+					Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
+				},
+				"sensitive": {
+					Constraint:  schema.LiteralType{Type: cty.Bool},
+					IsOptional:  true,
+					Description: lang.Markdown("Whether the variable contains sensitive material and should be hidden in the UI"),
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"validation": {
+					Description: lang.Markdown("Custom validation rule to restrict what value is expected for the variable"),
+					Body: &schema.BodySchema{
+						Attributes: map[string]*schema.AttributeSchema{
+							"condition": {
+								Constraint: schema.LiteralType{Type: cty.Bool},
+								IsRequired: true,
+								Description: lang.Markdown("Condition under which a variable value is valid, " +
+									"e.g. `length(var.example) >= 4` enforces minimum of 4 characters"),
+							},
+							"error_message": {
+								Constraint: schema.LiteralType{Type: cty.String},
+								IsRequired: true,
+								Description: lang.Markdown("Error message to present when the variable is considered invalid, " +
+									"i.e. when `condition` evaluates to `false`"),
+							},
 						},
 					},
 				},
 			},
 		},
-	},
+	}
 }

--- a/internal/schema/1.1/root.go
+++ b/internal/schema/1.1/root.go
@@ -14,5 +14,7 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs := v015_mod.ModuleSchema(v)
 	bs.Blocks["moved"] = movedBlockSchema
 	bs.Blocks["terraform"] = patchTerraformBlockSchema(bs.Blocks["terraform"])
+	bs.Blocks["variable"] = patchVariableBlockSchema(bs.Blocks["variable"])
+
 	return bs
 }

--- a/internal/schema/1.1/variable_block.go
+++ b/internal/schema/1.1/variable_block.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func patchVariableBlockSchema(bs *schema.BlockSchema) *schema.BlockSchema {
+	bs.Body.Attributes["nullable"] = &schema.AttributeSchema{
+		Constraint:  schema.LiteralType{Type: cty.Bool},
+		IsOptional:  true,
+		Description: lang.Markdown("Specifies whether `null` is a valid value for this variable"),
+	}
+
+	return bs
+}


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-ls/issues/894

## UX
Before
<img width="799" alt="CleanShot 2023-09-27 at 09 55 28@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/93ceffa6-466e-4969-a9db-e75e870e50b8">

After
<img width="806" alt="CleanShot 2023-09-27 at 09 55 09@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/00c0b924-a06e-4693-aa4b-10eae016431e">
