### PR TITLE
versiongen: Ensure that only stable versions are latest

### DIFF
--- a/internal/versiongen/gen.go
+++ b/internal/versiongen/gen.go
@@ -82,14 +82,29 @@ var (
 	// we don't have schema for older versions
 	oldestVersion := version.Must(version.NewVersion("0.12.0"))
 
+	latestVersion, err := firstStableVersion(releases)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	err = tpl.Execute(output, data{
 		Releases:      releases,
-		LatestVersion: releases[0].Version,
+		LatestVersion: latestVersion,
 		OldestVersion: oldestVersion,
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func firstStableVersion(releases []release) (*version.Version, error) {
+	for _, release := range releases {
+		if release.Version.Prerelease() == "" {
+			return release.Version, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unable to find stable version in %d given releases", len(releases))
 }
 
 func GetTerraformReleases() ([]release, error) {


### PR DESCRIPTION
This aligns our generator logic better with the rest of the Terraform ecosystem, which generally assumes that any open-ended or missing constraint means latest _stable_ version, rather than any latest version.

This can already be demonstrated with the upcoming 1.6, which has a number of pre-releases but we want to treat `1.5.7` as the latest version.

Notably, users _can_ still opt into the pre-release by specifying the exact version as constraint, for example:

```hcl
terraform {
  required_version = "1.6.0-beta3"
}
```

I did not regenerate the file in this PR as due to the recent changes concerning 1.6 schema, tests would fail.