### PR TITLE
Regenerate Terraform core versions

### DIFF
--- a/schema/core_schema_test.go
+++ b/schema/core_schema_test.go
@@ -16,7 +16,7 @@ import (
 	mod_v0_14 "github.com/hashicorp/terraform-schema/internal/schema/0.14"
 	mod_v1_1 "github.com/hashicorp/terraform-schema/internal/schema/1.1"
 	mod_v1_2 "github.com/hashicorp/terraform-schema/internal/schema/1.2"
-	mod_v1_5 "github.com/hashicorp/terraform-schema/internal/schema/1.5"
+	mod_v1_6 "github.com/hashicorp/terraform-schema/internal/schema/1.6"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 )
 
@@ -123,7 +123,7 @@ func TestCoreModuleSchemaForConstraint(t *testing.T) {
 		},
 		{
 			version.Constraints{},
-			mod_v1_5.ModuleSchema(version.Must(version.NewVersion("1.5.0"))),
+			mod_v1_6.ModuleSchema(version.Must(version.NewVersion("1.6.0"))),
 			nil,
 		},
 		{

--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,9 +7,23 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.5.0"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.5.7"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.6.0-rc1")),
+		version.Must(version.NewVersion("1.6.0-beta3")),
+		version.Must(version.NewVersion("1.6.0-beta2")),
+		version.Must(version.NewVersion("1.6.0-beta1")),
+		version.Must(version.NewVersion("1.6.0-alpha20230816")),
+		version.Must(version.NewVersion("1.6.0-alpha20230802")),
+		version.Must(version.NewVersion("1.6.0-alpha20230719")),
+		version.Must(version.NewVersion("1.5.7")),
+		version.Must(version.NewVersion("1.5.6")),
+		version.Must(version.NewVersion("1.5.5")),
+		version.Must(version.NewVersion("1.5.4")),
+		version.Must(version.NewVersion("1.5.3")),
+		version.Must(version.NewVersion("1.5.2")),
+		version.Must(version.NewVersion("1.5.1")),
 		version.Must(version.NewVersion("1.5.0")),
 		version.Must(version.NewVersion("1.5.0-rc2")),
 		version.Must(version.NewVersion("1.5.0-rc1")),
@@ -17,6 +31,7 @@ var (
 		version.Must(version.NewVersion("1.5.0-beta1")),
 		version.Must(version.NewVersion("1.5.0-alpha20230504")),
 		version.Must(version.NewVersion("1.5.0-alpha20230405")),
+		version.Must(version.NewVersion("1.4.7")),
 		version.Must(version.NewVersion("1.4.6")),
 		version.Must(version.NewVersion("1.4.5")),
 		version.Must(version.NewVersion("1.4.4")),
@@ -29,6 +44,7 @@ var (
 		version.Must(version.NewVersion("1.4.0-beta1")),
 		version.Must(version.NewVersion("1.4.0-alpha20221207")),
 		version.Must(version.NewVersion("1.4.0-alpha20221109")),
+		version.Must(version.NewVersion("1.3.10")),
 		version.Must(version.NewVersion("1.3.9")),
 		version.Must(version.NewVersion("1.3.8")),
 		version.Must(version.NewVersion("1.3.7")),


### PR DESCRIPTION
We can bump the `LatestVersion` manually in a separate PR (and also add it to the slice) prior to the LS release.