### PR TITLE
schema/versions: Add 1.6.0 ahead of expected release

### DIFF
--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.5.7"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.6.0"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.6.0")),
 		version.Must(version.NewVersion("1.6.0-rc1")),
 		version.Must(version.NewVersion("1.6.0-beta3")),
 		version.Must(version.NewVersion("1.6.0-beta2")),


### PR DESCRIPTION
This change technically violates https://github.com/hashicorp/terraform-schema/blob/f812ddc72c354bbdfd7fc4553eed332c862e627b/schema/versions_gen.go#L1 but it allows the next release of Terraform LS to be released ahead of Terraform 1.6.0 and still provide compatibility to users.