### PR TITLE
fix: Ensure target_platform is recognised in nested connection block

### DIFF
--- a/internal/schema/0.15/root.go
+++ b/internal/schema/0.15/root.go
@@ -15,6 +15,7 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 	bs.Blocks["terraform"] = patchTerraformBlockSchema(bs.Blocks["terraform"])
 	bs.Blocks["resource"].Body.Blocks["provisioner"].DependentBody = ProvisionerDependentBodies(v)
 	bs.Blocks["resource"].Body.Blocks["connection"].DependentBody = ConnectionDependentBodies(v)
+	bs.Blocks["resource"].Body.Blocks["provisioner"].Body.Blocks["connection"].DependentBody = ConnectionDependentBodies(v)
 
 	return bs
 }


### PR DESCRIPTION
As discovered in https://github.com/hashicorp/vscode-terraform/issues/1573#issuecomment-1748331505 we did not previously recognise `target_platform` attribute inside of the nested `connection` block.

## UX Before

![Screenshot 2023-10-05 at 10 04 02](https://github.com/hashicorp/terraform-schema/assets/287584/3382d2c1-b3a5-4e31-a24d-4c445de704c0)

## UX After

![Screenshot 2023-10-05 at 10 04 36](https://github.com/hashicorp/terraform-schema/assets/287584/642d62af-80cc-4152-8995-cf36ea97c3cf)

![Screenshot 2023-10-05 at 10 05 06](https://github.com/hashicorp/terraform-schema/assets/287584/a0ce4572-0d17-4938-b2cf-4ed7393d7b0d)

![Screenshot 2023-10-05 at 10 04 58](https://github.com/hashicorp/terraform-schema/assets/287584/1f079ef9-05e9-44cf-9936-ddeb07efc04f)
