### PR TITLE
schema: Introduce v1.3 proxy related fields for provisioner `connection`

### DIFF
--- a/internal/schema/1.3/connection_block.go
+++ b/internal/schema/1.3/connection_block.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+
+	v015_mod "github.com/hashicorp/terraform-schema/internal/schema/0.15"
+)
+
+func ConnectionDependentBodies(v *version.Version) map[schema.SchemaKey]*schema.BodySchema {
+	bodies := v015_mod.ConnectionDependentBodies(v)
+
+	ssh := schema.NewSchemaKey(schema.DependencyKeys{
+		Attributes: []schema.AttributeDependent{
+			{
+				Name: "type",
+				Expr: schema.ExpressionValue{Static: cty.StringVal("ssh")},
+			},
+		},
+	})
+
+	// See https://github.com/hashicorp/terraform/commit/4cfb6bc8
+	bodies[ssh].Attributes["proxy_scheme"] = &schema.AttributeSchema{
+		Constraint: schema.OneOf{
+			schema.LiteralValue{Value: cty.StringVal("http")},
+			schema.LiteralValue{Value: cty.StringVal("https")},
+		},
+		IsOptional: true,
+		Description: lang.Markdown("Scheme to use to connect to the proxy (`http` or `https`). " +
+			"Defaults to `http`."),
+	}
+	bodies[ssh].Attributes["proxy_host"] = &schema.AttributeSchema{
+		Constraint: schema.AnyExpression{OfType: cty.String},
+		IsOptional: true,
+		Description: lang.Markdown("Host to connect to in order to enable SSH over HTTP connection. " +
+			"This host will be connected to first, and then the `host` or `bastion_host` connection " +
+			"will be made from there."),
+	}
+	bodies[ssh].Attributes["proxy_port"] = &schema.AttributeSchema{
+		Constraint:  schema.AnyExpression{OfType: cty.Number},
+		IsOptional:  true,
+		Description: lang.Markdown("The port to use connect to the `proxy_host`"),
+	}
+	bodies[ssh].Attributes["proxy_user_name"] = &schema.AttributeSchema{
+		Constraint:  schema.AnyExpression{OfType: cty.String},
+		IsOptional:  true,
+		Description: lang.Markdown("The username to use to connect to the `proxy_host`"),
+	}
+	bodies[ssh].Attributes["proxy_user_password"] = &schema.AttributeSchema{
+		Constraint:  schema.AnyExpression{OfType: cty.String},
+		IsOptional:  true,
+		Description: lang.Markdown("The password to use to connect to the `proxy_host`"),
+	}
+
+	return bodies
+}

--- a/internal/schema/1.3/root.go
+++ b/internal/schema/1.3/root.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+
+	v1_2_mod "github.com/hashicorp/terraform-schema/internal/schema/1.2"
+)
+
+func ModuleSchema(v *version.Version) *schema.BodySchema {
+	bs := v1_2_mod.ModuleSchema(v)
+	bs.Blocks["resource"].Body.Blocks["connection"].DependentBody = ConnectionDependentBodies(v)
+	bs.Blocks["resource"].Body.Blocks["provisioner"].Body.Blocks["connection"].DependentBody = ConnectionDependentBodies(v)
+
+	return bs
+}

--- a/internal/schema/1.4/root.go
+++ b/internal/schema/1.4/root.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
 
-	v1_2_mod "github.com/hashicorp/terraform-schema/internal/schema/1.2"
+	v1_3_mod "github.com/hashicorp/terraform-schema/internal/schema/1.3"
 )
 
 func ModuleSchema(v *version.Version) *schema.BodySchema {
-	bs := v1_2_mod.ModuleSchema(v)
+	bs := v1_3_mod.ModuleSchema(v)
 	bs.Blocks["resource"].Body.Blocks["provisioner"].DependentBody = ProvisionerDependentBodies(v)
 
 	return bs


### PR DESCRIPTION
As discovered in https://github.com/hashicorp/vscode-terraform/issues/1573#issuecomment-1748331505 we forgot to update the schema when some changes were introduced in 1.3 to the `connection` block of SSH provisioner.

Original PR: https://github.com/hashicorp/terraform/pull/30274

--- 

## UX before

![Screenshot 2023-10-05 at 10 17 20](https://github.com/hashicorp/terraform-schema/assets/287584/0d164861-e6a4-42c9-9743-3e3b5715f3bc)

## UX after

![2023-10-05 10 15 51](https://github.com/hashicorp/terraform-schema/assets/287584/a0e7c4fa-dde7-4294-9350-fc0cba739218)
