### PR TITLE
schema: Make `cloud` `organization` optional

### DIFF
--- a/internal/schema/1.1/terraform.go
+++ b/internal/schema/1.1/terraform.go
@@ -23,7 +23,7 @@ func patchTerraformBlockSchema(bs *schema.BlockSchema) *schema.BlockSchema {
 				},
 				"organization": {
 					Constraint:  schema.LiteralType{Type: cty.String},
-					IsRequired:  true,
+					IsOptional:  true,
 					Description: lang.PlainText("The name of the organization containing the targeted workspace(s)."),
 				},
 				"token": {


### PR DESCRIPTION
As reported in https://github.com/hashicorp/vscode-terraform/issues/1577 the `organization` attribute is in fact optional.

The [documentation](https://developer.hashicorp.com/terraform/cli/cloud/settings#organization) is somewhat confusing in that it states that it both `organization` and `workspaces` are required fields

<img width="700" alt="Screenshot 2023-10-06 at 09 21 22" src="https://github.com/hashicorp/terraform-schema/assets/287584/5f6f004e-d1c6-4f13-9f99-46c97901afb2">

but [further down](https://developer.hashicorp.com/terraform/cli/cloud/settings#tf_cloud_organization) it basically says that it's _not_, implying that it can be supplied via env variables

<img width="692" alt="Screenshot 2023-10-06 at 09 23 39" src="https://github.com/hashicorp/terraform-schema/assets/287584/7a096e72-7b89-4ac5-aed6-809f122635ee">

I suppose it's still technically "required" in the sense it has to come from _somewhere_ but it's not required in the configuration.