### PR TITLE
Fix provider attribute to block conversion

### DIFF
--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -181,12 +181,30 @@ func bodySchemaForCtyObjectType(typ cty.Type) *schema.BodySchema {
 	ret := &schema.BodySchema{
 		Attributes: make(map[string]*schema.AttributeSchema, len(attrTypes)),
 	}
+	blocks := make(map[string]*schema.BlockSchema, 0)
+
 	for name, attrType := range attrTypes {
 		ret.Attributes[name] = &schema.AttributeSchema{
 			Constraint: convertAttributeTypeToConstraint(attrType),
 			IsOptional: true,
 		}
+
+		if typeCanBeBlocks(attrType) {
+			fAttr := tfjson.SchemaAttribute{
+				AttributeType: attrType,
+			}
+			blockSchema, ok := blockSchemaForAttribute(&fAttr)
+			if !ok {
+				continue
+			}
+			blocks[name] = blockSchema
+		}
 	}
+
+	if len(blocks) > 0 {
+		ret.Blocks = blocks
+	}
+
 	return ret
 }
 


### PR DESCRIPTION
To mimic Terraform's built-in backwards-compatible logic, where list(object) or set(object) attributes are also accessible as blocks, we check all attributes to see if they match those types. But we only did this for the top-level attributes of a block, and didn't check nested attributes. This PR fixes that.

The example in https://github.com/hashicorp/vscode-terraform/issues/1594 had three attributes, that were also available as a block: `managed_disk`, `network_interface`, and `unmanaged_disk`. All three are of type set(object) and encoded as such in the provider schema.

We convert them to blocks in
https://github.com/hashicorp/terraform-schema/blob/8c9761673ed527e56b1b9ac7a60fa97ea005c5c3/schema/convert_json.go#L123-L134

and so they show up for completion in the top-level dynamic block
<img width="330" alt="CleanShot 2023-10-27 at 14 57 22@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/5fdec473-d74f-42b8-bfb6-4b8fdc4a8e20">

`managed_disk` contains the attribute `target_disk_encryption` with type list(object) that also could be a block, but we never tried to convert it. So it never showed up for completion in a nested dynamic block and was marked as a problem by the schema validation.

## UX
**Before**
<img width="680" alt="CleanShot 2023-10-26 at 11 08 45@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/ed6023a6-7892-40ff-a3b2-4aa058ccca34">
<img width="751" alt="CleanShot 2023-10-26 at 11 08 15@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/7a48cf49-6043-4dd6-808a-20aa81aacae8">

**After**
<img width="592" alt="CleanShot 2023-10-26 at 11 07 43@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/3438272d-1d81-4a1a-8120-14cc658bac4c">
<img width="713" alt="CleanShot 2023-10-26 at 11 07 34@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/a67de924-8df0-4e80-a4b5-39d60aa5fe3b">


---

* Resolves https://github.com/hashicorp/vscode-terraform/issues/1594