### PR TITLE
Skip inferring module inputs for default values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.6.1
-	github.com/hashicorp/hcl-lang v0.0.0-20231005141915-402c82e5ccb1
+	github.com/hashicorp/hcl-lang v0.0.0-20231102085329-caa96d65d15b
 	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/terraform-exec v0.19.0
 	github.com/hashicorp/terraform-json v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.6.1 h1:IGxShH7AVhPaSuSJpKtVi/EFORNjO+OYVJJrAtGG2mY=
 github.com/hashicorp/hc-install v0.6.1/go.mod h1:0fW3jpg+wraYSnFDJ6Rlie3RvLf1bIqVIkzoon4KoVE=
-github.com/hashicorp/hcl-lang v0.0.0-20231005141915-402c82e5ccb1 h1:GEjoNvn9WaZDMpUtNs0VB+FtP/ndclhr10Zcmkraax4=
-github.com/hashicorp/hcl-lang v0.0.0-20231005141915-402c82e5ccb1/go.mod h1:67DxtN9WnM5dTdDPFn79G2Azgs9b5/8yOKP5LU2XBIc=
+github.com/hashicorp/hcl-lang v0.0.0-20231102085329-caa96d65d15b h1:j8TNMurAPPN05V2/FXOo16c6RpNKY57ZV7iqwO0vAOc=
+github.com/hashicorp/hcl-lang v0.0.0-20231102085329-caa96d65d15b/go.mod h1:f8Trmd1qEAs00+y4etS5uTDqYhU3Z/pxJgzsTwWXWM8=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
 github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/terraform-exec v0.19.0 h1:FpqZ6n50Tk95mItTSS9BjeOVUb4eg81SpgVtZNNtFSM=
@@ -137,8 +137,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
-golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
+golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
+golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/schema/0.12/variable_block.go
+++ b/internal/schema/0.12/variable_block.go
@@ -23,8 +23,7 @@ func variableBlockSchema(v *version.Version) *schema.BlockSchema {
 			ScopeId:      refscope.VariableScope,
 			AsReference:  true,
 			AsTypeOf: &schema.BlockAsTypeOf{
-				AttributeExpr:  "type",
-				AttributeValue: "default",
+				AttributeExpr: "type",
 			},
 		},
 		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variable},

--- a/internal/schema/0.14/variable_block.go
+++ b/internal/schema/0.14/variable_block.go
@@ -23,8 +23,7 @@ func variableBlockSchema() *schema.BlockSchema {
 			ScopeId:      refscope.VariableScope,
 			AsReference:  true,
 			AsTypeOf: &schema.BlockAsTypeOf{
-				AttributeExpr:  "type",
-				AttributeValue: "default",
+				AttributeExpr: "type",
 			},
 		},
 		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variable},

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -112,7 +112,7 @@ func schemaForDependentModuleBlock(module module.InstalledModuleCall, modMeta *m
 
 	for name, modVar := range modMeta.Variables {
 		aSchema := moduleVarToAttribute(modVar)
-		varType := typeOfModuleVar(modVar)
+		varType := modVar.Type
 		aSchema.Constraint = convertAttributeTypeToConstraint(varType)
 		aSchema.OriginForTarget = &schema.PathTarget{
 			Address: schema.Address{

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -31,11 +31,9 @@ func schemaForDeclaredDependentModuleBlock(module module.DeclaredModuleCall, mod
 		}
 
 		typ := input.Type
-		defaultType := input.Default.Type()
-		if typ == cty.DynamicPseudoType && (defaultType != cty.DynamicPseudoType && defaultType != cty.NilType) {
-			typ = defaultType
+		if typ == cty.NilType {
+			typ = cty.DynamicPseudoType
 		}
-
 		aSchema.Constraint = convertAttributeTypeToConstraint(typ)
 
 		attributes[input.Name] = aSchema
@@ -111,8 +109,11 @@ func schemaForDependentModuleBlock(module module.InstalledModuleCall, modMeta *m
 	attributes := make(map[string]*schema.AttributeSchema, 0)
 
 	for name, modVar := range modMeta.Variables {
-		aSchema := moduleVarToAttribute(modVar)
 		varType := modVar.Type
+		if varType == cty.NilType {
+			varType = cty.DynamicPseudoType
+		}
+		aSchema := moduleVarToAttribute(modVar)
 		aSchema.Constraint = convertAttributeTypeToConstraint(varType)
 		aSchema.OriginForTarget = &schema.PathTarget{
 			Address: schema.Address{

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -104,7 +104,7 @@ func TestSchemaForDependentModuleBlock_basic(t *testing.T) {
 				},
 			},
 			"another_var": {
-				Constraint: schema.AnyExpression{OfType: cty.String},
+				Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
 				IsOptional: true,
 				OriginForTarget: &schema.PathTarget{
 					Address: schema.Address{
@@ -117,7 +117,7 @@ func TestSchemaForDependentModuleBlock_basic(t *testing.T) {
 					},
 					Constraints: schema.Constraints{
 						ScopeId: "variable",
-						Type:    cty.String,
+						Type:    cty.DynamicPseudoType,
 					},
 				},
 			},
@@ -512,7 +512,7 @@ func TestSchemaForDeclaredDependentModuleBlock_basic(t *testing.T) {
 				IsRequired:  true,
 			},
 			"foo_var": {
-				Constraint: schema.AnyExpression{OfType: cty.Number},
+				Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
 				IsOptional: true,
 			},
 			"another_var": {

--- a/schema/variable_schema.go
+++ b/schema/variable_schema.go
@@ -16,7 +16,7 @@ func SchemaForVariables(vars map[string]module.Variable, modPath string) (*schem
 
 	for name, modVar := range vars {
 		aSchema := moduleVarToAttribute(modVar)
-		varType := typeOfModuleVar(modVar)
+		varType := modVar.Type
 		aSchema.Constraint = schema.LiteralType{Type: varType}
 		aSchema.OriginForTarget = &schema.PathTarget{
 			Address: schema.Address{
@@ -59,15 +59,4 @@ func moduleVarToAttribute(modVar module.Variable) *schema.AttributeSchema {
 	}
 
 	return aSchema
-}
-
-func typeOfModuleVar(modVar module.Variable) cty.Type {
-	if (modVar.Type == cty.DynamicPseudoType || modVar.Type == cty.NilType) &&
-		modVar.DefaultValue != cty.NilVal {
-		// infer type from default value if one is not specified
-		// or when it's "any"
-		return modVar.DefaultValue.Type()
-	}
-
-	return modVar.Type
 }

--- a/schema/variable_schema_test.go
+++ b/schema/variable_schema_test.go
@@ -94,49 +94,6 @@ func TestSchemaForVariables(t *testing.T) {
 				},
 			}},
 		},
-		{
-			"attribute with type from default value",
-			map[string]module.Variable{
-				"name": {
-					Description:  "name of the module",
-					Type:         cty.DynamicPseudoType,
-					DefaultValue: cty.StringVal("default"),
-				},
-				"id": {
-					Description:  "id of the module",
-					Type:         cty.NilType,
-					DefaultValue: cty.NumberIntVal(42),
-				},
-			},
-			&schema.BodySchema{Attributes: map[string]*schema.AttributeSchema{
-				"name": {
-					Description: lang.MarkupContent{
-						Value: "name of the module",
-						Kind:  lang.PlainTextKind,
-					},
-					IsOptional: true,
-					Constraint: schema.LiteralType{Type: cty.String},
-					OriginForTarget: &schema.PathTarget{
-						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
-						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
-						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.String},
-					},
-				},
-				"id": {
-					Description: lang.MarkupContent{
-						Value: "id of the module",
-						Kind:  lang.PlainTextKind,
-					},
-					Constraint: schema.LiteralType{Type: cty.Number},
-					IsOptional: true,
-					OriginForTarget: &schema.PathTarget{
-						Address:     schema.Address{schema.StaticStep{Name: "var"}, schema.AttrNameStep{}},
-						Path:        lang.Path{Path: "./local", LanguageID: "terraform"},
-						Constraints: schema.Constraints{ScopeId: "variable", Type: cty.Number},
-					},
-				},
-			}},
-		},
 	}
 
 	modPath := "./local"


### PR DESCRIPTION
After removing type inference from default values in https://github.com/hashicorp/hcl-lang/pull/338, this PR does the same for module inputs. These also previously relied on variable defaults to get a type for a module input.

Without this, we can now pass a list of strings to tuple defaults, etc.

### UX Before
<img width="692" alt="CleanShot 2023-11-02 at 14 55 10@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/68ea2bbf-c18d-4ddb-9e36-e17719ccaa88">

### UX After
<img width="486" alt="CleanShot 2023-11-02 at 14 55 32@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/d53c6e68-aa83-4551-a6a9-6b1104ffbd18">

<img width="347" alt="CleanShot 2023-11-02 at 14 59 34@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/da2a0ee2-747f-45b6-b926-cd74379ddb8c">

---

* Depends on https://github.com/hashicorp/hcl-lang/pull/338
* Resolves https://github.com/hashicorp/vscode-terraform/issues/1592