### PR TITLE
Allow variable references in `depends_on`

### DIFF
--- a/internal/schema/0.12/data_block.go
+++ b/internal/schema/0.12/data_block.go
@@ -64,6 +64,7 @@ func datasourceBlockSchema(v *version.Version) *schema.BlockSchema {
 							schema.Reference{OfScopeId: refscope.DataScope},
 							schema.Reference{OfScopeId: refscope.ModuleScope},
 							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
 						},
 					},
 					IsOptional:  true,

--- a/internal/schema/0.12/output_block.go
+++ b/internal/schema/0.12/output_block.go
@@ -55,6 +55,7 @@ func outputBlockSchema() *schema.BlockSchema {
 							schema.Reference{OfScopeId: refscope.DataScope},
 							schema.Reference{OfScopeId: refscope.ModuleScope},
 							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
 						},
 					},
 					IsOptional:  true,

--- a/internal/schema/0.12/resource_block.go
+++ b/internal/schema/0.12/resource_block.go
@@ -64,6 +64,7 @@ func resourceBlockSchema(v *version.Version) *schema.BlockSchema {
 							schema.Reference{OfScopeId: refscope.DataScope},
 							schema.Reference{OfScopeId: refscope.ModuleScope},
 							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
 						},
 					},
 					IsOptional:  true,

--- a/internal/schema/0.13/module_block.go
+++ b/internal/schema/0.13/module_block.go
@@ -81,6 +81,7 @@ func moduleBlockSchema() *schema.BlockSchema {
 							schema.Reference{OfScopeId: refscope.DataScope},
 							schema.Reference{OfScopeId: refscope.ModuleScope},
 							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
 						},
 					},
 					IsOptional:  true,

--- a/internal/schema/1.5/check.go
+++ b/internal/schema/1.5/check.go
@@ -85,6 +85,7 @@ func scopedDataBlock() *schema.BlockSchema {
 							schema.Reference{OfScopeId: refscope.DataScope},
 							schema.Reference{OfScopeId: refscope.ModuleScope},
 							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
 						},
 					},
 					IsOptional:  true,


### PR DESCRIPTION
This PR allows variable references in `depends_on` aligning it with Terraform.

## UX

**Before**
<img width="590" alt="CleanShot 2023-10-27 at 15 58 38@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/15b4a826-ff25-4fce-95e7-0fbe93bfd802">

**After**
<img width="327" alt="CleanShot 2023-10-27 at 15 58 16@2x" src="https://github.com/hashicorp/terraform-schema/assets/45985/2b9a6aea-1c3b-4742-ab98-ee4f40a122a3">

---

* Resolves https://github.com/hashicorp/vscode-terraform/issues/1598
