### PR TITLE
Update version resolution for empty constraints

### DIFF
--- a/schema/versions.go
+++ b/schema/versions.go
@@ -19,19 +19,19 @@ func ResolveVersion(tfVersion *version.Version, tfCons version.Constraints) *ver
 		if coreVersion.GreaterThan(LatestAvailableVersion) {
 			return LatestAvailableVersion
 		}
-		if tfCons.Check(coreVersion) {
+		if len(tfCons) > 0 && tfCons.Check(coreVersion) {
 			return coreVersion
 		}
 	}
 
 	for _, v := range terraformVersions {
-		if tfCons.Check(v) && v.LessThan(OldestAvailableVersion) {
+		if len(tfCons) > 0 && tfCons.Check(v) && v.LessThan(OldestAvailableVersion) {
 			return OldestAvailableVersion
 		}
 		if tfVersion != nil && tfVersion.Core().Equal(v) {
 			return tfVersion.Core()
 		}
-		if tfCons.Check(v) {
+		if len(tfCons) > 0 && tfCons.Check(v) {
 			return v
 		}
 	}

--- a/schema/versions.go
+++ b/schema/versions.go
@@ -17,6 +17,14 @@ func ResolveVersion(tfVersion *version.Version, tfCons version.Constraints) *ver
 			return OldestAvailableVersion
 		}
 		if coreVersion.GreaterThan(LatestAvailableVersion) {
+			// We could simply return coreVersion or tfVersion here
+			// but we ensure the return version is actually known, i.e.
+			// that we actually have schema for it.
+			//
+			// Also we strip the pre-release part as it simplifies
+			// the version comparisons downstream (we don't care
+			// about differences between individual pre-releases
+			// of the same patch version).
 			for _, v := range terraformVersions {
 				if tfVersion.Equal(v) {
 					return coreVersion

--- a/schema/versions.go
+++ b/schema/versions.go
@@ -17,9 +17,14 @@ func ResolveVersion(tfVersion *version.Version, tfCons version.Constraints) *ver
 			return OldestAvailableVersion
 		}
 		if coreVersion.GreaterThan(LatestAvailableVersion) {
+			for _, v := range terraformVersions {
+				if tfVersion.Equal(v) {
+					return coreVersion
+				}
+			}
 			return LatestAvailableVersion
 		}
-		if len(tfCons) > 0 && tfCons.Check(coreVersion) {
+		if tfCons.Check(coreVersion) {
 			return coreVersion
 		}
 	}

--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,9 +7,13 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.6.1"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.6.3"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.7.0-alpha20231108")),
+		version.Must(version.NewVersion("1.7.0-alpha20231025")),
+		version.Must(version.NewVersion("1.6.3")),
+		version.Must(version.NewVersion("1.6.2")),
 		version.Must(version.NewVersion("1.6.1")),
 		version.Must(version.NewVersion("1.6.0")),
 		version.Must(version.NewVersion("1.6.0-rc1")),

--- a/schema/versions_test.go
+++ b/schema/versions_test.go
@@ -61,6 +61,16 @@ func TestResolveVersion(t *testing.T) {
 			nil,
 			version.Must(version.NewVersion("1.5.3")),
 		},
+		{
+			version.Must(version.NewVersion("1.7.0-alpha20231025")),
+			nil,
+			version.Must(version.NewVersion("1.7.0")),
+		},
+		{
+			version.Must(version.NewVersion("1.6.0-beta2")),
+			nil,
+			version.Must(version.NewVersion("1.6.0")),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/schema/versions_test.go
+++ b/schema/versions_test.go
@@ -29,12 +29,12 @@ func TestResolveVersion(t *testing.T) {
 		{
 			nil,
 			version.MustConstraints(version.NewConstraint("< 0.12")),
-			version.Must(version.NewVersion("0.12.0")),
+			OldestAvailableVersion,
 		},
 		{
 			version.Must(version.NewVersion("0.11.0")),
 			nil,
-			version.Must(version.NewVersion("0.12.0")),
+			OldestAvailableVersion,
 		},
 		{
 			nil,


### PR DESCRIPTION
This PR regenerates the Terraform version list and fixes a bug with empty constraints.

If a pre-release was at the top of the version list, we returned it instead of `LatestAvailableVersion` as seen in [this test failure](https://github.com/hashicorp/terraform-schema/actions/runs/6813192400/job/18527202523?pr=295#step:8:246).