### PR TITLE
Fix Terraform version for `skip_s3_checksum` (s3 backend)

### DIFF
--- a/internal/schema/backends/backends.go
+++ b/internal/schema/backends/backends.go
@@ -28,7 +28,7 @@ var (
 	v1_4_0   = version.Must(version.NewVersion("1.4.0"))
 	v1_6_0   = version.Must(version.NewVersion("1.6.0"))
 	v1_6_1   = version.Must(version.NewVersion("1.6.1"))
-	v1_6_2   = version.Must(version.NewVersion("1.6.2"))
+	v1_6_3   = version.Must(version.NewVersion("1.6.3"))
 	v1_6_4   = version.Must(version.NewVersion("1.6.4"))
 )
 

--- a/internal/schema/backends/s3.go
+++ b/internal/schema/backends/s3.go
@@ -485,7 +485,7 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 		}
 	}
 
-	if v.GreaterThanOrEqual(v1_6_2) {
+	if v.GreaterThanOrEqual(v1_6_3) {
 		bodySchema.Attributes["skip_s3_checksum"] = &schema.AttributeSchema{
 			Constraint:  schema.LiteralType{Type: cty.Bool},
 			IsOptional:  true,


### PR DESCRIPTION
It turns out that this change was released in 1.6.3 instead of 1.6.2 as planned:
https://github.com/hashicorp/terraform/blob/v1.6.4/CHANGELOG.md#163-november-1-2023