### PR TITLE
Remove unused `exprFunc`

### DIFF
--- a/schema/variable_schema.go
+++ b/schema/variable_schema.go
@@ -41,8 +41,6 @@ func SchemaForVariables(vars map[string]module.Variable, modPath string) (*schem
 	}, nil
 }
 
-type exprFunc func(cty.Type) schema.ExprConstraints
-
 func moduleVarToAttribute(modVar module.Variable) *schema.AttributeSchema {
 	aSchema := &schema.AttributeSchema{
 		IsSensitive: modVar.IsSensitive,


### PR DESCRIPTION
Type was removed from hcl-lang in https://github.com/hashicorp/hcl-lang/pull/354 and was unused anyway.