### PR TITLE
Deprecate `use_legacy_workflow` in  S3 Backend (v1.7)

### DIFF
--- a/internal/schema/backends/backends.go
+++ b/internal/schema/backends/backends.go
@@ -30,6 +30,7 @@ var (
 	v1_6_1   = version.Must(version.NewVersion("1.6.1"))
 	v1_6_3   = version.Must(version.NewVersion("1.6.3"))
 	v1_6_4   = version.Must(version.NewVersion("1.6.4"))
+	v1_7_0   = version.Must(version.NewVersion("1.7.0"))
 )
 
 func BackendTypesAsOneOfConstraint(tfVersion *version.Version) schema.OneOf {

--- a/internal/schema/backends/s3.go
+++ b/internal/schema/backends/s3.go
@@ -541,5 +541,14 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 		}
 	}
 
+	if v.GreaterThanOrEqual(v1_7_0) {
+		bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
+			Constraint:   schema.LiteralType{Type: cty.Bool},
+			IsOptional:   true,
+			Description:  lang.Markdown("Use the legacy authentication workflow, preferring environment variables over backend configuration."),
+			IsDeprecated: true,
+		}
+	}
+
 	return bodySchema
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-schema/issues/304