### PR TITLE
Refactor `SchemaMerger` interface

### DIFF
--- a/module/meta.go
+++ b/module/meta.go
@@ -13,11 +13,11 @@ type Meta struct {
 	Path      string
 	Filenames []string
 
+	CoreRequirements     version.Constraints
 	Backend              *Backend
 	Cloud                *backend.Cloud
 	ProviderReferences   map[ProviderRef]tfaddr.Provider
 	ProviderRequirements ProviderRequirements
-	CoreRequirements     version.Constraints
 	Variables            map[string]Variable
 	Outputs              map[string]Output
 	ModuleCalls          map[string]DeclaredModuleCall

--- a/schema/functions_merge_test.go
+++ b/schema/functions_merge_test.go
@@ -93,7 +93,7 @@ func TestFunctionsMerger_FunctionsForModule_18(t *testing.T) {
 	}
 
 	fm := NewFunctionsMerger(coreFunctions)
-	fm.SetSchemaReader(&testJsonSchemaReader{
+	fm.SetStateReader(&testJsonSchemaReader{
 		ps: &tfjson.ProviderSchemas{
 			FormatVersion: "1.0",
 			Schemas:       providerSchemaWithFunctions,
@@ -150,7 +150,7 @@ func TestFunctionsMerger_FunctionsForModule_18(t *testing.T) {
 
 func TestFunctionsMerger_FunctionsForModule_17(t *testing.T) {
 	fm := NewFunctionsMerger(map[string]schema.FunctionSignature{})
-	fm.SetSchemaReader(&testJsonSchemaReader{
+	fm.SetStateReader(&testJsonSchemaReader{
 		ps: &tfjson.ProviderSchemas{
 			FormatVersion: "1.0",
 			Schemas:       providerSchemaWithFunctions,

--- a/schema/variable_schema.go
+++ b/schema/variable_schema.go
@@ -11,6 +11,34 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// AnySchemaForVariableCollection returns a schema for collecting all
+// variables in a variable file. It doesn't check if a variable has
+// been defined in the module or not.
+//
+// We can use this schema to collect variable references without waiting
+// on the module metadata.
+func AnySchemaForVariableCollection(modPath string) *schema.BodySchema {
+	return &schema.BodySchema{
+		AnyAttribute: &schema.AttributeSchema{
+			OriginForTarget: &schema.PathTarget{
+				Address: schema.Address{
+					schema.StaticStep{Name: "var"},
+					schema.AttrNameStep{},
+				},
+				Path: lang.Path{
+					Path:       modPath,
+					LanguageID: ModuleLanguageID,
+				},
+				Constraints: schema.Constraints{
+					ScopeId: refscope.VariableScope,
+					Type:    cty.DynamicPseudoType,
+				},
+			},
+			Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+		},
+	}
+}
+
 func SchemaForVariables(vars map[string]module.Variable, modPath string) (*schema.BodySchema, error) {
 	attributes := make(map[string]*schema.AttributeSchema)
 


### PR DESCRIPTION
As part of the language server state splitting (https://github.com/hashicorp/terraform-ls/issues/1626), we now have to get the declared module calls and the installed module calls from different sources.

We now have a separate method for each of them instead of a combined one. With the unified `StateReader` terraform-schema now also has less knowledge about where in particular the language server stores the state.

The diff is easier to review with "Hide whitespace" enabled.