### PR TITLE
Only merge provider-defined functions for Terraform `>= 1.8`

### DIFF
--- a/schema/core_schema.go
+++ b/schema/core_schema.go
@@ -30,6 +30,7 @@ var (
 	v1_5  = version.Must(version.NewVersion("1.5"))
 	v1_6  = version.Must(version.NewVersion("1.6"))
 	v1_7  = version.Must(version.NewVersion("1.7"))
+	v1_8  = version.Must(version.NewVersion("1.8"))
 )
 
 // CoreModuleSchemaForVersion finds a module schema which is relevant

--- a/schema/functions_merge.go
+++ b/schema/functions_merge.go
@@ -40,6 +40,10 @@ func (m *FunctionsMerger) FunctionsForModule(meta *tfmod.Meta) (map[string]schem
 		return m.coreFunctions, nil
 	}
 
+	if m.terraformVersion.LessThan(v1_8) {
+		return m.coreFunctions, nil
+	}
+
 	mergedFunctions := make(map[string]schema.FunctionSignature, len(m.coreFunctions))
 	for fName, fSig := range m.coreFunctions {
 		mergedFunctions[fName] = *fSig.Copy()

--- a/schema/functions_merge.go
+++ b/schema/functions_merge.go
@@ -6,13 +6,15 @@ package schema
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
 	tfmod "github.com/hashicorp/terraform-schema/module"
 )
 
 type FunctionsMerger struct {
-	coreFunctions map[string]schema.FunctionSignature
-	schemaReader  SchemaReader
+	coreFunctions    map[string]schema.FunctionSignature
+	terraformVersion *version.Version
+	schemaReader     SchemaReader
 }
 
 func NewFunctionsMerger(coreFunctions map[string]schema.FunctionSignature) *FunctionsMerger {
@@ -23,6 +25,10 @@ func NewFunctionsMerger(coreFunctions map[string]schema.FunctionSignature) *Func
 
 func (m *FunctionsMerger) SetSchemaReader(sr SchemaReader) {
 	m.schemaReader = sr
+}
+
+func (m *FunctionsMerger) SetTerraformVersion(v *version.Version) {
+	m.terraformVersion = v
 }
 
 func (m *FunctionsMerger) FunctionsForModule(meta *tfmod.Meta) (map[string]schema.FunctionSignature, error) {


### PR DESCRIPTION
This PR extends the function merger with a check for the available Terraform version.

If the version is less than 1.8, we'll return early and not include the provider-defined functions.