### PR TITLE
Conclude Terraform Experiments Completion

### DIFF
--- a/internal/schema/0.14/terraform.go
+++ b/internal/schema/0.14/terraform.go
@@ -29,7 +29,7 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 					Constraint: schema.LiteralType{Type: cty.String},
 					IsOptional: true,
 					Description: lang.Markdown("A set of experimental language features to enable. Consult the documentation" +
-						" for the version of Terraform you arte using for a list of available experiments"),
+						" for the version of Terraform you are using for a list of available experiments"),
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{

--- a/internal/schema/0.14/terraform.go
+++ b/internal/schema/0.14/terraform.go
@@ -26,20 +26,10 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 						"with this configuration, e.g. `~> 0.12`"),
 				},
 				"experiments": {
-					Constraint: schema.Set{
-						Elem: schema.OneOf{
-							schema.Keyword{
-								Keyword: "module_variable_optional_attrs",
-								Name:    "feature",
-							},
-							schema.Keyword{
-								Keyword: "provider_sensitive_attrs",
-								Name:    "feature",
-							},
-						},
-					},
-					IsOptional:  true,
-					Description: lang.Markdown("A set of experimental language features to enable"),
+					Constraint: schema.LiteralType{Type: cty.String},
+					IsOptional: true,
+					Description: lang.Markdown("A set of experimental language features to enable. Consult the documentation" +
+						" for the version of Terraform you arte using for a list of available experiments"),
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{

--- a/internal/schema/0.14/terraform.go
+++ b/internal/schema/0.14/terraform.go
@@ -26,10 +26,20 @@ func terraformBlockSchema(v *version.Version) *schema.BlockSchema {
 						"with this configuration, e.g. `~> 0.12`"),
 				},
 				"experiments": {
-					Constraint: schema.LiteralType{Type: cty.String},
-					IsOptional: true,
-					Description: lang.Markdown("A set of experimental language features to enable. Consult the documentation" +
-						" for the version of Terraform you are using for a list of available experiments"),
+					Constraint: schema.Set{
+						Elem: schema.OneOf{
+							schema.Keyword{
+								Keyword: "module_variable_optional_attrs",
+								Name:    "feature",
+							},
+							schema.Keyword{
+								Keyword: "provider_sensitive_attrs",
+								Name:    "feature",
+							},
+						},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("A set of experimental language features to enable"),
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{

--- a/internal/schema/1.8/root.go
+++ b/internal/schema/1.8/root.go
@@ -1,0 +1,17 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+
+	v1_7_mod "github.com/hashicorp/terraform-schema/internal/schema/1.7"
+)
+
+func ModuleSchema(v *version.Version) *schema.BodySchema {
+	bs := v1_7_mod.ModuleSchema(v)
+	bs.Blocks["terraform"] = patchTerraformBlockSchema(bs.Blocks["terraform"])
+	return bs
+}

--- a/internal/schema/1.8/terraform.go
+++ b/internal/schema/1.8/terraform.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+)
+
+func patchTerraformBlockSchema(bs *schema.BlockSchema) *schema.BlockSchema {
+	// removes module_variable_optional_attrs experiment (defined in 0.14)
+	bs.Body.Attributes["experiments"] = &schema.AttributeSchema{
+		Constraint: schema.Set{
+			Elem: schema.OneOf{
+				schema.Keyword{
+					Keyword: "provider_sensitive_attrs",
+					Name:    "feature",
+				},
+			},
+		},
+		IsOptional:  true,
+		Description: lang.Markdown("A set of experimental language features to enable"),
+	}
+
+	return bs
+}

--- a/schema/core_schema.go
+++ b/schema/core_schema.go
@@ -16,6 +16,7 @@ import (
 	mod_v1_5 "github.com/hashicorp/terraform-schema/internal/schema/1.5"
 	mod_v1_6 "github.com/hashicorp/terraform-schema/internal/schema/1.6"
 	mod_v1_7 "github.com/hashicorp/terraform-schema/internal/schema/1.7"
+	mod_v1_8 "github.com/hashicorp/terraform-schema/internal/schema/1.8"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 	v1_5  = version.Must(version.NewVersion("1.5"))
 	v1_6  = version.Must(version.NewVersion("1.6"))
 	v1_7  = version.Must(version.NewVersion("1.7"))
+	v1_8  = version.Must(version.NewVersion("1.8"))
 )
 
 // CoreModuleSchemaForVersion finds a module schema which is relevant
@@ -37,6 +39,9 @@ var (
 // It will return error if such schema cannot be found.
 func CoreModuleSchemaForVersion(v *version.Version) (*schema.BodySchema, error) {
 	ver := v.Core()
+	if ver.GreaterThanOrEqual(v1_8) {
+		return mod_v1_8.ModuleSchema(ver), nil
+	}
 	if ver.GreaterThanOrEqual(v1_7) {
 		return mod_v1_7.ModuleSchema(ver), nil
 	}


### PR DESCRIPTION
This commit concludes the work on the Terraform experiments feature by removing the list of features from completion for the `experiments` attriubute.

Terraform language experiments are temporary features that are added, removed, and/or concluded at cadences too unpredictable to be included in this completion list. These are used in alpha or beta builds of Terraform and are changed frequently enough that it would either always be out of date or require constant releases to keep up to date.

As such, the completion list for the `experiments` attribute has been removed and documentation added to instruct the user to look to documentation for the particular release they are using for a list of features that can be enabled.

Closes #328