### PR TITLE
Remove use_legacy_workflow from S3 backend

### DIFF
--- a/internal/schema/backends/backends.go
+++ b/internal/schema/backends/backends.go
@@ -31,6 +31,7 @@ var (
 	v1_6_3   = version.Must(version.NewVersion("1.6.3"))
 	v1_6_4   = version.Must(version.NewVersion("1.6.4"))
 	v1_7_0   = version.Must(version.NewVersion("1.7.0"))
+	v1_8_0   = version.Must(version.NewVersion("1.8.0"))
 )
 
 func BackendTypesAsOneOfConstraint(tfVersion *version.Version) schema.OneOf {

--- a/internal/schema/backends/s3.go
+++ b/internal/schema/backends/s3.go
@@ -553,7 +553,7 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 
 	if v.GreaterThanOrEqual(v1_8_0) {
 		// In Terraform 1.8 the use_legacy_workflow argument is be removed to encourage consistency with the AWS SDKs
-		bodySchema.Attributes["use_legacy_workflow"] = nil
+		delete(bodySchema.Attributes, "use_legacy_workflow")
 	}
 
 	return bodySchema

--- a/internal/schema/backends/s3.go
+++ b/internal/schema/backends/s3.go
@@ -445,11 +445,6 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 				},
 			},
 		}
-		bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
-			Constraint:  schema.LiteralType{Type: cty.Bool},
-			IsOptional:  true,
-			Description: lang.Markdown("Use the legacy authentication workflow, preferring environment variables over backend configuration."),
-		}
 		bodySchema.Attributes["custom_ca_bundle"] = &schema.AttributeSchema{
 			Constraint:  schema.LiteralType{Type: cty.String},
 			IsOptional:  true,
@@ -541,13 +536,24 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 		}
 	}
 
-	if v.GreaterThanOrEqual(v1_7_0) {
+	bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
+		Constraint:  schema.LiteralType{Type: cty.Bool},
+		IsOptional:  true,
+		Description: lang.Markdown("Use the legacy authentication workflow, preferring environment variables over backend configuration."),
+	}
+
+	if v.GreaterThanOrEqual(v1_7_0) && v.LessThan(v1_8_0) {
 		bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
 			Constraint:   schema.LiteralType{Type: cty.Bool},
 			IsOptional:   true,
 			Description:  lang.Markdown("Use the legacy authentication workflow, preferring environment variables over backend configuration."),
 			IsDeprecated: true,
 		}
+	}
+
+	if v.GreaterThanOrEqual(v1_8_0) {
+		// In Terraform 1.8 the use_legacy_workflow argument is be removed to encourage consistency with the AWS SDKs
+		bodySchema.Attributes["use_legacy_workflow"] = nil
 	}
 
 	return bodySchema


### PR DESCRIPTION
In Terraform 1.8 the use_legacy_workflow argument will be removed to encourage consistency with the AWS SDKs. The backend will now search for credentials in the same order as the default provider chain in the AWS SDKs and AWS CLI.

Closes #326
