### PR TITLE
Update functions hash for 1.8

### DIFF
--- a/internal/funcs/generated/README.md
+++ b/internal/funcs/generated/README.md
@@ -24,4 +24,4 @@ Run `go generate ./internal/funcs/generated`. This command will:
 1. Create a new Go file with the function signatures of that Terraform version.
 1. Regenerate the function signature selection in `functions.go`.
 
-If everything looks solid, update the `functionSignatureHash` with the one from the output, and commit all changes.
+**If everything looks solid, update the `functionSignatureHash` with the one from the output, and commit all changes.**

--- a/internal/funcs/generated/gen/gen.go
+++ b/internal/funcs/generated/gen/gen.go
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	functionSignatureHash = "3edcd73cb8643903dde229b04dfc36d10d8dd6679e7804ea37001be38650d950"
+	functionSignatureHash = "42e102cb1520d1c9f8fcc97937b2350eb19e393867370b96bed7cb3c9db04c7a"
 )
 
 func main() {


### PR DESCRIPTION
As a quick follow up to #340, this PR updates the function hash to match the Terraform version used to generate the new function signatures.

Before:
```
2024/04/09 11:52:18 ensuring terraform is installed
2024/04/09 11:52:31 using Terraform 1.8.0-rc2 (/var/folders/zm/53tbvp79543_c8kpdvxvdzgh0000gq/T/hcinstall3326278210/terraform)
2024/04/09 11:52:31 generating new signatures for "42e102cb1520d1c9f8fcc97937b2350eb19e393867370b96bed7cb3c9db04c7a"
2024/04/09 11:52:31 found versions [1.8.0 1.5.0 1.4.0], regenerating includes
```

After:
```
2024/04/09 11:56:12 ensuring terraform is installed
2024/04/09 11:56:22 using Terraform 1.8.0-rc2 (/var/folders/zm/53tbvp79543_c8kpdvxvdzgh0000gq/T/hcinstall2159135680/terraform)
2024/04/09 11:56:22 function signatures haven't changed, nothing to do here
```

Closes https://github.com/hashicorp/terraform-schema/issues/319