### PR TITLE
Ensure `use_legacy_workflow` is only available from >= 1.6

### DIFF
--- a/internal/schema/backends/s3.go
+++ b/internal/schema/backends/s3.go
@@ -445,6 +445,11 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 				},
 			},
 		}
+		bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
+			Constraint:  schema.LiteralType{Type: cty.Bool},
+			IsOptional:  true,
+			Description: lang.Markdown("Use the legacy authentication workflow, preferring environment variables over backend configuration."),
+		}
 		bodySchema.Attributes["custom_ca_bundle"] = &schema.AttributeSchema{
 			Constraint:  schema.LiteralType{Type: cty.String},
 			IsOptional:  true,
@@ -536,13 +541,7 @@ func s3Backend(v *version.Version) *schema.BodySchema {
 		}
 	}
 
-	bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
-		Constraint:  schema.LiteralType{Type: cty.Bool},
-		IsOptional:  true,
-		Description: lang.Markdown("Use the legacy authentication workflow, preferring environment variables over backend configuration."),
-	}
-
-	if v.GreaterThanOrEqual(v1_7_0) && v.LessThan(v1_8_0) {
+	if v.GreaterThanOrEqual(v1_7_0) {
 		bodySchema.Attributes["use_legacy_workflow"] = &schema.AttributeSchema{
 			Constraint:   schema.LiteralType{Type: cty.Bool},
 			IsOptional:   true,

--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,9 +7,23 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.7.0"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.8.0"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.9.0-alpha20240404")),
+		version.Must(version.NewVersion("1.8.0")),
+		version.Must(version.NewVersion("1.8.0-rc2")),
+		version.Must(version.NewVersion("1.8.0-rc1")),
+		version.Must(version.NewVersion("1.8.0-beta1")),
+		version.Must(version.NewVersion("1.8.0-alpha20240228")),
+		version.Must(version.NewVersion("1.8.0-alpha20240216")),
+		version.Must(version.NewVersion("1.8.0-alpha20240214")),
+		version.Must(version.NewVersion("1.8.0-alpha20240131")),
+		version.Must(version.NewVersion("1.7.5")),
+		version.Must(version.NewVersion("1.7.4")),
+		version.Must(version.NewVersion("1.7.3")),
+		version.Must(version.NewVersion("1.7.2")),
+		version.Must(version.NewVersion("1.7.1")),
 		version.Must(version.NewVersion("1.7.0")),
 		version.Must(version.NewVersion("1.7.0-rc2")),
 		version.Must(version.NewVersion("1.7.0-rc1")),


### PR DESCRIPTION
Quick follow up to https://github.com/hashicorp/terraform-schema/pull/338 to ensure that `use_legacy_workflow` is only available from >= 1.6.

I also regenerated the available Terraform versions, so that the language server is able to pick 1.8.0 as the latest version.