### PR TITLE
(TF-18286) Add support for Stack metadata

### DIFF
--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/terraform-schema/stack"
+)
+
+func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	filenames := make([]string, 0)
+
+	mod := newDecodedStack()
+	for filename, f := range files {
+		filenames = append(filenames, filename)
+		// TODO need more stack metas
+		fDiags := loadStackFromFile(f, mod)
+		diags = append(diags, fDiags...)
+	}
+
+	sort.Strings(filenames)
+
+	components := make(map[string]stack.Component)
+	for key, variable := range mod.Components {
+		components[key] = *variable
+	}
+
+	variables := make(map[string]stack.Variable)
+	for key, variable := range mod.Variables {
+		variables[key] = *variable
+	}
+
+	outputs := make(map[string]stack.Output)
+	for key, output := range mod.Outputs {
+		outputs[key] = *output
+	}
+
+	providerRequirements := make(map[string]stack.ProviderRequirement)
+	for key, providerRequirement := range mod.ProviderRequirements {
+		providerRequirements[key] = stack.ProviderRequirement{
+			Source:             providerRequirement.Source,
+			VersionConstraints: providerRequirement.VersionConstraints,
+		}
+	}
+
+	return &stack.Meta{
+		Path:                 path,
+		Filenames:            filenames,
+		Components:           components,
+		Variables:            variables,
+		Outputs:              outputs,
+		ProviderRequirements: providerRequirements,
+	}, diags
+}

--- a/earlydecoder/stacks/decoder_test.go
+++ b/earlydecoder/stacks/decoder_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-schema/stack"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+)
+
+type testCase struct {
+	name          string
+	cfg           string
+	expectedMeta  *stack.Meta
+	expectedError hcl.Diagnostics
+}
+
+var customComparer = []cmp.Option{
+	cmp.Comparer(compareVersionConstraint),
+	ctydebug.CmpOptions,
+}
+
+func TestLoadStack(t *testing.T) {
+	path := t.TempDir()
+
+	testCases := []testCase{
+		{
+			"empty config",
+			``,
+			&stack.Meta{
+				Path:                 path,
+				Filenames:            []string{"test.tf"},
+				Components:           map[string]stack.Component{},
+				Variables:            map[string]stack.Variable{},
+				Outputs:              map[string]stack.Output{},
+				ProviderRequirements: map[string]stack.ProviderRequirement{},
+			},
+			nil,
+		},
+		{
+			"complete component",
+			`component "test" {
+	source = "github.com/acme/infra/core"
+	version = ">= 1.0, < 2.0"
+	inputs = {
+		"key" = "value"
+	}
+}`,
+			&stack.Meta{
+				Path:                 path,
+				Filenames:            []string{"test.tf"},
+				Components:           map[string]stack.Component{"test": {Source: "github.com/acme/infra/core", Version: version.MustConstraints(version.NewConstraint(">= 1.0, < 2.0"))}},
+				Variables:            map[string]stack.Variable{},
+				Outputs:              map[string]stack.Output{},
+				ProviderRequirements: map[string]stack.ProviderRequirement{},
+			},
+			nil,
+		},
+		{
+			"complete required_providers",
+			`required_providers {
+  aws = {
+    source  = "hashicorp/aws"
+    version = "~> 5.7.0"
+  }
+  random = {
+    source  = "hashicorp/random"
+    version = "~> 3.5.1"
+  }
+}`,
+			&stack.Meta{
+				Path:       path,
+				Filenames:  []string{"test.tf"},
+				Components: map[string]stack.Component{},
+				Variables:  map[string]stack.Variable{},
+				Outputs:    map[string]stack.Output{},
+				ProviderRequirements: map[string]stack.ProviderRequirement{
+					"aws":    {Source: "hashicorp/aws", VersionConstraints: []string{"~> 5.7.0"}},
+					"random": {Source: "hashicorp/random", VersionConstraints: []string{"~> 3.5.1"}},
+				},
+			},
+			nil,
+		},
+	}
+
+	runTestCases(testCases, t, path)
+}
+
+func runTestCases(testCases []testCase, t *testing.T, path string) {
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tf", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+			files := map[string]*hcl.File{
+				"test.tf": f,
+			}
+
+			meta, diags := LoadStack(path, files)
+
+			if diff := cmp.Diff(tc.expectedError, diags, customComparer...); diff != "" {
+				t.Fatalf("expected errors doesn't match: %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedMeta, meta, customComparer...); diff != "" {
+				t.Fatalf("stack meta doesn't match: %s", diff)
+			}
+		})
+	}
+}
+
+func compareVersionConstraint(x, y *version.Constraint) bool {
+	return x.Equals(y)
+}

--- a/earlydecoder/stacks/load_stack.go
+++ b/earlydecoder/stacks/load_stack.go
@@ -21,7 +21,6 @@ type decodedStack struct {
 	Variables            map[string]*stack.Variable
 	Outputs              map[string]*stack.Output
 	ProviderRequirements map[string]*providerRequirement
-	ProviderConfigs      map[string]*providerConfig
 }
 
 func newDecodedStack() *decodedStack {
@@ -30,14 +29,7 @@ func newDecodedStack() *decodedStack {
 		Variables:            make(map[string]*stack.Variable),
 		Outputs:              make(map[string]*stack.Output),
 		ProviderRequirements: make(map[string]*providerRequirement),
-		ProviderConfigs:      make(map[string]*providerConfig),
 	}
-}
-
-// providerConfig represents a provider block in the configuration
-type providerConfig struct {
-	Name  string
-	Alias string
 }
 
 // loadStackFromFile reads given file, interprets it and stores in given Stack

--- a/earlydecoder/stacks/load_stack.go
+++ b/earlydecoder/stacks/load_stack.go
@@ -1,0 +1,209 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/terraform-schema/stack"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// decodedStack is the type representing a decoded Terraform stack.
+type decodedStack struct {
+	Components           map[string]*stack.Component
+	Variables            map[string]*stack.Variable
+	Outputs              map[string]*stack.Output
+	ProviderRequirements map[string]*providerRequirement
+	ProviderConfigs      map[string]*providerConfig
+}
+
+func newDecodedStack() *decodedStack {
+	return &decodedStack{
+		Components:           make(map[string]*stack.Component),
+		Variables:            make(map[string]*stack.Variable),
+		Outputs:              make(map[string]*stack.Output),
+		ProviderRequirements: make(map[string]*providerRequirement),
+		ProviderConfigs:      make(map[string]*providerConfig),
+	}
+}
+
+// providerConfig represents a provider block in the configuration
+type providerConfig struct {
+	Name  string
+	Alias string
+}
+
+// loadStackFromFile reads given file, interprets it and stores in given Stack
+// This is useful for any caller which does tokenization/parsing on its own
+// e.g. because it will reuse these parsed files later for more detailed
+// interpretation.
+func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	content, _, contentDiags := file.Body.PartialContent(rootSchema)
+	diags = append(diags, contentDiags...)
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "component":
+			content, _, contentDiags := block.Body.PartialContent(componentSchema)
+			diags = append(diags, contentDiags...)
+
+			if len(block.Labels) != 1 || block.Labels[0] == "" {
+				continue
+			}
+
+			name := block.Labels[0]
+			source := ""
+			var versionCons version.Constraints
+
+			var valDiags hcl.Diagnostics
+			if attr, defined := content.Attributes["source"]; defined {
+				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &source)
+				diags = append(diags, valDiags...)
+			}
+
+			if attr, defined := content.Attributes["version"]; defined {
+				var versionStr string
+				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &versionStr)
+				diags = append(diags, valDiags...)
+				if versionStr != "" {
+					vc, err := version.NewConstraint(versionStr)
+					if err == nil {
+						versionCons = vc
+					}
+				}
+			}
+
+			ds.Components[name] = &stack.Component{
+				Source:  source,
+				Version: versionCons,
+			}
+		case "provider":
+			// there is no point to parsing provider blocks here, as they need the full
+			// context of the configuration to be parsed correctly
+		case "required_providers":
+			reqs, reqsDiags := decodeRequiredProvidersBlock(block)
+			diags = append(diags, reqsDiags...)
+			for name, req := range reqs {
+				if _, exists := ds.ProviderRequirements[name]; !exists {
+					ds.ProviderRequirements[name] = req
+				} else {
+					if req.Source != "" {
+						source := ds.ProviderRequirements[name].Source
+						if source != "" && source != req.Source {
+							diags = append(diags, &hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "Multiple provider source attributes",
+								Detail:   fmt.Sprintf("Found multiple source attributes for provider %s: %q, %q", name, source, req.Source),
+								Subject:  &block.DefRange,
+							})
+						} else {
+							ds.ProviderRequirements[name].Source = req.Source
+						}
+					}
+
+					ds.ProviderRequirements[name].VersionConstraints = append(ds.ProviderRequirements[name].VersionConstraints, req.VersionConstraints...)
+				}
+			}
+		case "variable":
+			// TODO: rename to input
+			content, _, contentDiags := block.Body.PartialContent(variableSchema)
+			diags = append(diags, contentDiags...)
+
+			if len(block.Labels) != 1 || block.Labels[0] == "" {
+				continue
+			}
+
+			name := block.Labels[0]
+			description := ""
+			var valDiags hcl.Diagnostics
+
+			if attr, defined := content.Attributes["description"]; defined {
+				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &description)
+				diags = append(diags, valDiags...)
+			}
+
+			varType := cty.DynamicPseudoType
+			var defaults *typeexpr.Defaults
+			if attr, defined := content.Attributes["type"]; defined {
+				varType, defaults, valDiags = typeexpr.TypeConstraintWithDefaults(attr.Expr)
+				diags = append(diags, valDiags...)
+			}
+
+			defaultValue := cty.NilVal
+			if attr, defined := content.Attributes["default"]; defined {
+				val, vDiags := attr.Expr.Value(nil)
+				diags = append(diags, vDiags...)
+				if !vDiags.HasErrors() {
+					if varType != cty.NilType {
+						var err error
+						val, err = convert.Convert(val, varType)
+						if err != nil {
+							diags = append(diags, &hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "Invalid default value for variable",
+								Detail:   fmt.Sprintf("This default value is not compatible with the variable's type constraint: %s.", err),
+								Subject:  attr.Expr.Range().Ptr(),
+							})
+							val = cty.DynamicVal
+						}
+					}
+
+					defaultValue = val
+				}
+			}
+
+			ds.Variables[name] = &stack.Variable{
+				Type:         varType,
+				Description:  description,
+				DefaultValue: defaultValue,
+				TypeDefaults: defaults,
+			}
+		case "output":
+			content, _, contentDiags := block.Body.PartialContent(outputSchema)
+			diags = append(diags, contentDiags...)
+
+			if len(block.Labels) != 1 || block.Labels[0] == "" {
+				continue
+			}
+
+			name := block.Labels[0]
+			description := ""
+			isSensitive := false
+			var valDiags hcl.Diagnostics
+			if attr, defined := content.Attributes["description"]; defined {
+				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &description)
+				diags = append(diags, valDiags...)
+			}
+
+			if attr, defined := content.Attributes["type"]; defined {
+				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &isSensitive)
+				diags = append(diags, valDiags...)
+			}
+
+			value := cty.NilVal
+			if attr, defined := content.Attributes["value"]; defined {
+				// TODO: Provide context w/ funcs and variables
+				val, diags := attr.Expr.Value(nil)
+				if !diags.HasErrors() {
+					value = val
+				}
+			}
+
+			ds.Outputs[name] = &stack.Output{
+				Description: description,
+				IsSensitive: isSensitive,
+				Value:       value,
+			}
+		}
+	}
+
+	return diags
+}

--- a/earlydecoder/stacks/provider_requirements.go
+++ b/earlydecoder/stacks/provider_requirements.go
@@ -1,0 +1,90 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type providerRequirement struct {
+	Source             string
+	VersionConstraints []string
+}
+
+func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequirement, hcl.Diagnostics) {
+	attrs, diags := block.Body.JustAttributes()
+	reqs := make(map[string]*providerRequirement)
+	for name, attr := range attrs {
+		kvs, mapDiags := hcl.ExprMap(attr.Expr)
+		if mapDiags.HasErrors() {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid required_providers object",
+				Detail:   "Required providers entries must be objects for stacks configuration files.",
+				Subject:  attr.Expr.Range().Ptr(),
+			})
+			continue
+		}
+
+		var pr providerRequirement
+
+		for _, kv := range kvs {
+			key, keyDiags := kv.Key.Value(nil)
+			if keyDiags.HasErrors() {
+				diags = append(diags, keyDiags...)
+				continue
+			}
+
+			if key.Type() != cty.String {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid Attribute",
+					Detail:   fmt.Sprintf("Invalid attribute value for provider requirement: %#v", key),
+					Subject:  kv.Key.Range().Ptr(),
+				})
+				continue
+			}
+
+			switch key.AsString() {
+			case "version":
+				version, valDiags := kv.Value.Value(nil)
+				if valDiags.HasErrors() || !version.Type().Equals(cty.String) {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unsuitable value type",
+						Detail:   "Unsuitable value: string required",
+						Subject:  attr.Expr.Range().Ptr(),
+					})
+					continue
+				}
+				if !version.IsNull() {
+					pr.VersionConstraints = append(pr.VersionConstraints, version.AsString())
+				}
+
+			case "source":
+				source, valDiags := kv.Value.Value(nil)
+				if valDiags.HasErrors() || !source.Type().Equals(cty.String) {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Unsuitable value type",
+						Detail:   "Unsuitable value: string required",
+						Subject:  attr.Expr.Range().Ptr(),
+					})
+					continue
+				}
+
+				if !source.IsNull() {
+					pr.Source = source.AsString()
+				}
+			}
+
+			reqs[name] = &pr
+		}
+	}
+
+	return reqs, diags
+}

--- a/earlydecoder/stacks/schema.go
+++ b/earlydecoder/stacks/schema.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+var rootSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "component",
+			LabelNames: []string{"name"},
+		},
+		{
+			Type:       "provider",
+			LabelNames: []string{"type", "name"},
+		},
+		{
+			Type: "required_providers",
+		},
+		{
+			Type:       "variable",
+			LabelNames: []string{"name"},
+		},
+		{
+			Type:       "output",
+			LabelNames: []string{"name"},
+		},
+	},
+}
+
+var componentSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "source",
+		},
+		{
+			Name: "inputs",
+		},
+		{
+			Name: "version",
+		},
+		{
+			Name: "providers",
+		},
+	},
+}
+
+var variableSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "description",
+		},
+		{
+			Name: "type",
+		},
+		{
+			Name: "default",
+		},
+	},
+}
+
+var outputSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "description",
+		},
+		{
+			Name: "value",
+		},
+		{
+			Name: "type",
+		},
+	},
+}

--- a/earlydecoder/stacks/schema.go
+++ b/earlydecoder/stacks/schema.go
@@ -14,10 +14,6 @@ var rootSchema = &hcl.BodySchema{
 			LabelNames: []string{"name"},
 		},
 		{
-			Type:       "provider",
-			LabelNames: []string{"type", "name"},
-		},
-		{
 			Type: "required_providers",
 		},
 		{
@@ -37,13 +33,7 @@ var componentSchema = &hcl.BodySchema{
 			Name: "source",
 		},
 		{
-			Name: "inputs",
-		},
-		{
 			Name: "version",
-		},
-		{
-			Name: "providers",
 		},
 	},
 }

--- a/internal/schema/stacks/1.9/component_block.go
+++ b/internal/schema/stacks/1.9/component_block.go
@@ -41,7 +41,7 @@ func componentBlockSchema() *schema.BlockSchema {
 						Elem: schema.Reference{OfScopeId: refscope.ModuleScope}, // TODO: This should be refscope.InputScope ?
 					},
 				},
-				"versions": {
+				"version": {
 					Description: lang.Markdown("Accepts a comma-separated list of version constraints for registry modules"),
 					IsOptional:  true,
 					Constraint: schema.List{

--- a/stack/component.go
+++ b/stack/component.go
@@ -1,0 +1,8 @@
+package stack
+
+import "github.com/hashicorp/go-version"
+
+type Component struct {
+	Source  string
+	Version version.Constraints
+}

--- a/stack/meta.go
+++ b/stack/meta.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stack
+
+import (
+	"github.com/hashicorp/go-version"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+type Meta struct {
+	Path      string
+	Filenames []string
+
+	Components           map[string]Component
+	Variables            map[string]Variable
+	Outputs              map[string]Output
+	ProviderRequirements map[string]ProviderRequirement
+}
+
+type ProviderRequirements map[tfaddr.Provider]version.Constraints // ??
+
+func (pr ProviderRequirements) Equals(reqs ProviderRequirements) bool {
+	if len(pr) != len(reqs) {
+		return false
+	}
+
+	for pAddr, vCons := range pr {
+		c, ok := reqs[pAddr]
+		if !ok {
+			return false
+		}
+		if !vCons.Equals(c) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type ProviderRef struct {
+	LocalName string
+
+	// If not empty, Alias identifies which non-default (aliased) provider
+	// configuration this address refers to.
+	Alias string
+}

--- a/stack/meta.go
+++ b/stack/meta.go
@@ -18,30 +18,3 @@ type Meta struct {
 	ProviderRequirements map[string]ProviderRequirement
 }
 
-type ProviderRequirements map[tfaddr.Provider]version.Constraints // ??
-
-func (pr ProviderRequirements) Equals(reqs ProviderRequirements) bool {
-	if len(pr) != len(reqs) {
-		return false
-	}
-
-	for pAddr, vCons := range pr {
-		c, ok := reqs[pAddr]
-		if !ok {
-			return false
-		}
-		if !vCons.Equals(c) {
-			return false
-		}
-	}
-
-	return true
-}
-
-type ProviderRef struct {
-	LocalName string
-
-	// If not empty, Alias identifies which non-default (aliased) provider
-	// configuration this address refers to.
-	Alias string
-}

--- a/stack/output.go
+++ b/stack/output.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stack
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Output struct {
+	Description string
+	IsSensitive bool
+	Value       cty.Value
+}

--- a/stack/provider_requirements.go
+++ b/stack/provider_requirements.go
@@ -1,0 +1,6 @@
+package stack
+
+type ProviderRequirement struct {
+	Source             string
+	VersionConstraints []string
+}

--- a/stack/variable.go
+++ b/stack/variable.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stack
+
+import (
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Variable struct {
+	Description string
+	Type        cty.Type
+
+	// DefaultValue represents default value if one is defined
+	// and is decodable without errors, else cty.NilVal
+	DefaultValue cty.Value
+
+	// TypeDefaults represents any default values for optional object
+	// attributes assuming Type is of cty.Object and has defaults.
+	//
+	// Any relationships between DefaultValue & TypeDefaults are left
+	// for downstream to deal with using e.g. TypeDefaults.Apply().
+	TypeDefaults *typeexpr.Defaults
+}


### PR DESCRIPTION
This adds support for loading stack metadata from a set of Stack files. The metadata is loaded into a `stack.Meta` struct which contains the path to the stack, the filenames of the files that were loaded, and maps of components, variables, and outputs. The `stack.Meta` struct also contains a map of provider requirements which is a map of provider addresses to version constraints.