### PR TITLE
Update module schema merging logic for remote module sources

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -1386,9 +1386,10 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
-						InputNames: []string{},
+						LocalName:     "name",
+						RawSourceAddr: "registry.terraform.io/terraform-aws-modules/vpc/aws",
+						SourceAddr:    tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
+						InputNames:    []string{},
 						RangePtr: &hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 2, Column: 15, Byte: 15},
@@ -1443,10 +1444,11 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: tfaddr.MustParseModuleSource("terraform-aws-modules/vpc/aws"),
-						Version:    version.MustConstraints(version.NewConstraint("1.0.0")),
-						InputNames: []string{},
+						LocalName:     "name",
+						RawSourceAddr: "terraform-aws-modules/vpc/aws",
+						SourceAddr:    tfaddr.MustParseModuleSource("terraform-aws-modules/vpc/aws"),
+						Version:       version.MustConstraints(version.NewConstraint("1.0.0")),
+						InputNames:    []string{},
 						RangePtr: &hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 2, Column: 15, Byte: 15},
@@ -1472,9 +1474,10 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: module.LocalSourceAddr("./local"),
-						InputNames: []string{},
+						LocalName:     "name",
+						RawSourceAddr: "./local",
+						SourceAddr:    module.LocalSourceAddr("./local"),
+						InputNames:    []string{},
 						RangePtr: &hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 2, Column: 15, Byte: 15},
@@ -1502,8 +1505,9 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: module.LocalSourceAddr("./local"),
+						LocalName:     "name",
+						RawSourceAddr: "./local",
+						SourceAddr:    module.LocalSourceAddr("./local"),
 						InputNames: []string{
 							"one", "two",
 						},
@@ -1518,7 +1522,7 @@ module "name" {
 			nil,
 		},
 		{
-			"modules with unknown source",
+			"modules with remote source",
 			`
 module "name" {
 	source = "github.com/terraform-aws-modules/terraform-aws-security-group"
@@ -1532,13 +1536,43 @@ module "name" {
 				Filenames:            []string{"test.tf"},
 				ModuleCalls: map[string]module.DeclaredModuleCall{
 					"name": {
-						LocalName:  "name",
-						SourceAddr: module.UnknownSourceAddr("github.com/terraform-aws-modules/terraform-aws-security-group"),
-						InputNames: []string{},
+						LocalName:     "name",
+						RawSourceAddr: "github.com/terraform-aws-modules/terraform-aws-security-group",
+						SourceAddr:    module.RemoteSourceAddr("git::https://github.com/terraform-aws-modules/terraform-aws-security-group.git"),
+						InputNames:    []string{},
 						RangePtr: &hcl.Range{
 							Filename: "test.tf",
 							Start:    hcl.Pos{Line: 2, Column: 15, Byte: 15},
 							End:      hcl.Pos{Line: 4, Column: 2, Byte: 92},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"modules with unknown source",
+			`
+module "name" {
+	source = "file::/test"
+}`,
+			&module.Meta{
+				Path:                 path,
+				ProviderReferences:   map[module.ProviderRef]tfaddr.Provider{},
+				ProviderRequirements: map[tfaddr.Provider]version.Constraints{},
+				Variables:            map[string]module.Variable{},
+				Outputs:              map[string]module.Output{},
+				Filenames:            []string{"test.tf"},
+				ModuleCalls: map[string]module.DeclaredModuleCall{
+					"name": {
+						LocalName:     "name",
+						RawSourceAddr: "file::/test",
+						SourceAddr:    module.UnknownSourceAddr("file::/test"),
+						InputNames:    []string{},
+						RangePtr: &hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 2, Column: 15, Byte: 15},
+							End:      hcl.Pos{Line: 4, Column: 2, Byte: 42},
 						},
 					},
 				},

--- a/earlydecoder/load_module.go
+++ b/earlydecoder/load_module.go
@@ -333,11 +333,12 @@ func loadModuleFromFile(file *hcl.File, mod *decodedModule) hcl.Diagnostics {
 			}
 
 			mod.ModuleCalls[name] = &module.DeclaredModuleCall{
-				LocalName:  name,
-				SourceAddr: module.ParseModuleSourceAddr(source),
-				Version:    versionCons,
-				InputNames: inputNames,
-				RangePtr:   rng,
+				LocalName:     name,
+				RawSourceAddr: source,
+				SourceAddr:    module.ParseModuleSourceAddr(source),
+				Version:       versionCons,
+				InputNames:    inputNames,
+				RangePtr:      rng,
 			}
 		}
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -1,0 +1,100 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+)
+
+var RemoteSourceDetectors = []Detector{
+	new(GitHubDetector),
+	new(GitDetector),
+	new(BitBucketDetector),
+	new(GCSDetector),
+	new(S3Detector),
+}
+
+// Detector defines the interface that an invalid URL or a URL with a blank
+// scheme is passed through in order to determine if its shorthand for
+// something else well-known.
+type Detector interface {
+	// Detect will detect whether the string matches a known pattern to
+	// turn it into a proper URL.
+	Detect(string) (string, bool, error)
+}
+
+// Detect turns a source string into another source string if it is
+// detected to be of a known pattern.
+//
+// The third parameter should be the list of detectors to use in the
+// order to try them. If you don't want to configure this, just use
+// the global Detectors variable.
+//
+// This is safe to be called with an already valid source string: Detect
+// will just return it.
+func Detect(src string, ds []Detector) (string, error) {
+	getForce, getSrc := getForcedGetter(src)
+
+	// Separate out the subdir if there is one, we don't pass that to detect
+	getSrc, subDir := SourceDirSubdir(getSrc)
+
+	u, err := url.Parse(getSrc)
+	if err == nil && u.Scheme != "" {
+		// Valid URL
+		return src, nil
+	}
+
+	for _, d := range ds {
+		result, ok, err := d.Detect(getSrc)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			continue
+		}
+
+		var detectForce string
+		detectForce, result = getForcedGetter(result)
+		result, detectSubdir := SourceDirSubdir(result)
+
+		// If we have a subdir from the detection, then prepend it to our
+		// requested subdir.
+		if detectSubdir != "" {
+			if subDir != "" {
+				subDir = filepath.Join(detectSubdir, subDir)
+			} else {
+				subDir = detectSubdir
+			}
+		}
+
+		if subDir != "" {
+			u, err := url.Parse(result)
+			if err != nil {
+				return "", fmt.Errorf("error parsing URL: %s", err)
+			}
+			u.Path += "//" + subDir
+
+			// a subdir may contain wildcards, but in order to support them we
+			// have to ensure the path isn't escaped.
+			u.RawPath = u.Path
+
+			result = u.String()
+		}
+
+		// Preserve the forced getter if it exists. We try to use the
+		// original set force first, followed by any force set by the
+		// detector.
+		if getForce != "" {
+			result = fmt.Sprintf("%s::%s", getForce, result)
+		} else if detectForce != "" {
+			result = fmt.Sprintf("%s::%s", detectForce, result)
+		}
+
+		return result, nil
+	}
+
+	return "", fmt.Errorf("invalid source string: %s", src)
+}

--- a/internal/detect/detect_bitbucket.go
+++ b/internal/detect/detect_bitbucket.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// BitBucketDetector implements Detector to detect BitBucket URLs and turn
+// them into URLs that the Git or Hg Getter can understand.
+type BitBucketDetector struct{}
+
+func (d *BitBucketDetector) Detect(src string) (string, bool, error) {
+	if len(src) == 0 {
+		return "", false, nil
+	}
+
+	if strings.HasPrefix(src, "bitbucket.org/") {
+		return d.detectHTTP(src)
+	}
+
+	return "", false, nil
+}
+
+func (d *BitBucketDetector) detectHTTP(src string) (string, bool, error) {
+	u, err := url.Parse("https://" + src)
+	if err != nil {
+		return "", true, fmt.Errorf("error parsing BitBucket URL: %s", err)
+	}
+
+	// We need to get info on this BitBucket repository to determine whether
+	// it is Git or Hg.
+	var info struct {
+		SCM string `json:"scm"`
+	}
+	infoUrl := "https://api.bitbucket.org/2.0/repositories" + u.Path
+	resp, err := http.Get(infoUrl)
+	if err != nil {
+		return "", true, fmt.Errorf("error looking up BitBucket URL: %s", err)
+	}
+	if resp.StatusCode == 403 {
+		// A private repo
+		return "", true, fmt.Errorf(
+			"shorthand BitBucket URL can't be used for private repos, " +
+				"please use a full URL")
+	}
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&info); err != nil {
+		return "", true, fmt.Errorf("error looking up BitBucket URL: %s", err)
+	}
+
+	switch info.SCM {
+	case "git":
+		if !strings.HasSuffix(u.Path, ".git") {
+			u.Path += ".git"
+		}
+
+		return "git::" + u.String(), true, nil
+	case "hg":
+		return "hg::" + u.String(), true, nil
+	default:
+		return "", true, fmt.Errorf("unknown BitBucket SCM type: %s", info.SCM)
+	}
+}

--- a/internal/detect/detect_bitbucket_test.go
+++ b/internal/detect/detect_bitbucket_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const testBBUrl = "https://bitbucket.org/hashicorp/tf-test-git"
+
+func TestBitBucketDetector(t *testing.T) {
+	t.Parallel()
+
+	if _, err := http.Get(testBBUrl); err != nil {
+		t.Log("internet may not be working, skipping BB tests")
+		t.Skip()
+	}
+
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		// HTTP
+		{
+			"bitbucket.org/hashicorp/tf-test-git",
+			"git::https://bitbucket.org/hashicorp/tf-test-git.git",
+		},
+		{
+			"bitbucket.org/hashicorp/tf-test-git.git",
+			"git::https://bitbucket.org/hashicorp/tf-test-git.git",
+		},
+	}
+
+	f := new(BitBucketDetector)
+	for i, tc := range cases {
+		var err error
+		for i := 0; i < 3; i++ {
+			var output string
+			var ok bool
+			output, ok, err = f.Detect(tc.Input)
+			if err != nil {
+				if strings.Contains(err.Error(), "invalid character") {
+					continue
+				}
+
+				t.Fatalf("err: %s", err)
+			}
+			if !ok {
+				t.Fatal("not ok")
+			}
+
+			if output != tc.Output {
+				t.Fatalf("%d: bad: %#v", i, output)
+			}
+
+			break
+		}
+		if i >= 3 {
+			t.Fatalf("failure from bitbucket: %s", err)
+		}
+	}
+}

--- a/internal/detect/detect_gcs.go
+++ b/internal/detect/detect_gcs.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// GCSDetector implements Detector to detect GCS URLs and turn
+// them into URLs that the GCSGetter can understand.
+type GCSDetector struct{}
+
+func (d *GCSDetector) Detect(src string) (string, bool, error) {
+	if len(src) == 0 {
+		return "", false, nil
+	}
+
+	if strings.Contains(src, "googleapis.com/") {
+		return d.detectHTTP(src)
+	}
+
+	return "", false, nil
+}
+
+func (d *GCSDetector) detectHTTP(src string) (string, bool, error) {
+
+	parts := strings.Split(src, "/")
+	if len(parts) < 5 {
+		return "", false, fmt.Errorf(
+			"URL is not a valid GCS URL")
+	}
+	version := parts[2]
+	bucket := parts[3]
+	object := strings.Join(parts[4:], "/")
+
+	url, err := url.Parse(fmt.Sprintf("https://www.googleapis.com/storage/%s/%s/%s",
+		version, bucket, object))
+	if err != nil {
+		return "", false, fmt.Errorf("error parsing GCS URL: %s", err)
+	}
+
+	return "gcs::" + url.String(), true, nil
+}

--- a/internal/detect/detect_gcs_test.go
+++ b/internal/detect/detect_gcs_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"testing"
+)
+
+func TestGCSDetector(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			"www.googleapis.com/storage/v1/bucket/foo",
+			"gcs::https://www.googleapis.com/storage/v1/bucket/foo",
+		},
+		{
+			"www.googleapis.com/storage/v1/bucket/foo/bar",
+			"gcs::https://www.googleapis.com/storage/v1/bucket/foo/bar",
+		},
+		{
+			"www.googleapis.com/storage/v1/foo/bar.baz",
+			"gcs::https://www.googleapis.com/storage/v1/foo/bar.baz",
+		},
+	}
+
+	f := new(GCSDetector)
+	for i, tc := range cases {
+		output, ok, err := f.Detect(tc.Input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if !ok {
+			t.Fatal("not ok")
+		}
+
+		if output != tc.Output {
+			t.Fatalf("%d: bad: %#v", i, output)
+		}
+	}
+}

--- a/internal/detect/detect_git.go
+++ b/internal/detect/detect_git.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+// GitDetector implements Detector to detect Git SSH URLs such as
+// git@host.com:dir1/dir2 and converts them to proper URLs.
+type GitDetector struct{}
+
+func (d *GitDetector) Detect(src string) (string, bool, error) {
+	if len(src) == 0 {
+		return "", false, nil
+	}
+
+	u, err := detectSSH(src)
+	if err != nil {
+		return "", true, err
+	}
+	if u == nil {
+		return "", false, nil
+	}
+
+	// We require the username to be "git" to assume that this is a Git URL
+	if u.User.Username() != "git" {
+		return "", false, nil
+	}
+
+	return "git::" + u.String(), true, nil
+}

--- a/internal/detect/detect_git_test.go
+++ b/internal/detect/detect_git_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"testing"
+)
+
+func TestGitDetector(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			"git@github.com:hashicorp/foo.git",
+			"git::ssh://git@github.com/hashicorp/foo.git",
+		},
+		{
+			"git@github.com:org/project.git?ref=test-branch",
+			"git::ssh://git@github.com/org/project.git?ref=test-branch",
+		},
+		{
+			"git@github.com:hashicorp/foo.git//bar",
+			"git::ssh://git@github.com/hashicorp/foo.git//bar",
+		},
+		{
+			"git@github.com:hashicorp/foo.git?foo=bar",
+			"git::ssh://git@github.com/hashicorp/foo.git?foo=bar",
+		},
+		{
+			"git@github.xyz.com:org/project.git",
+			"git::ssh://git@github.xyz.com/org/project.git",
+		},
+		{
+			"git@github.xyz.com:org/project.git?ref=test-branch",
+			"git::ssh://git@github.xyz.com/org/project.git?ref=test-branch",
+		},
+		{
+			"git@github.xyz.com:org/project.git//module/a",
+			"git::ssh://git@github.xyz.com/org/project.git//module/a",
+		},
+		{
+			"git@github.xyz.com:org/project.git//module/a?ref=test-branch",
+			"git::ssh://git@github.xyz.com/org/project.git//module/a?ref=test-branch",
+		},
+		{
+			// Already in the canonical form, so no rewriting required
+			// When the ssh: protocol is used explicitly, we recognize it as
+			// URL form rather than SCP-like form, so the part after the colon
+			// is a port number, not part of the path.
+			"git::ssh://git@git.example.com:2222/hashicorp/foo.git",
+			"git::ssh://git@git.example.com:2222/hashicorp/foo.git",
+		},
+	}
+
+	f := new(GitDetector)
+	ds := []Detector{f}
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			output, err := Detect(tc.Input, ds)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if output != tc.Output {
+				t.Errorf("wrong result\ninput: %s\ngot:   %s\nwant:  %s", tc.Input, output, tc.Output)
+			}
+		})
+	}
+}

--- a/internal/detect/detect_github.go
+++ b/internal/detect/detect_github.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// GitHubDetector implements Detector to detect GitHub URLs and turn
+// them into URLs that the Git Getter can understand.
+type GitHubDetector struct{}
+
+func (d *GitHubDetector) Detect(src string) (string, bool, error) {
+	if len(src) == 0 {
+		return "", false, nil
+	}
+
+	if strings.HasPrefix(src, "github.com/") {
+		return d.detectHTTP(src)
+	}
+
+	return "", false, nil
+}
+
+func (d *GitHubDetector) detectHTTP(src string) (string, bool, error) {
+	parts := strings.Split(src, "/")
+	if len(parts) < 3 {
+		return "", false, fmt.Errorf(
+			"GitHub URLs should be github.com/username/repo")
+	}
+
+	urlStr := fmt.Sprintf("https://%s", strings.Join(parts[:3], "/"))
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return "", true, fmt.Errorf("error parsing GitHub URL: %s", err)
+	}
+
+	if !strings.HasSuffix(url.Path, ".git") {
+		url.Path += ".git"
+	}
+
+	if len(parts) > 3 {
+		url.Path += "//" + strings.Join(parts[3:], "/")
+	}
+
+	return "git::" + url.String(), true, nil
+}

--- a/internal/detect/detect_github_test.go
+++ b/internal/detect/detect_github_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"testing"
+)
+
+func TestGitHubDetector(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		// HTTP
+		{"github.com/hashicorp/foo", "git::https://github.com/hashicorp/foo.git"},
+		{"github.com/hashicorp/foo.git", "git::https://github.com/hashicorp/foo.git"},
+		{
+			"github.com/hashicorp/foo/bar",
+			"git::https://github.com/hashicorp/foo.git//bar",
+		},
+		{
+			"github.com/hashicorp/foo?foo=bar",
+			"git::https://github.com/hashicorp/foo.git?foo=bar",
+		},
+		{
+			"github.com/hashicorp/foo.git?foo=bar",
+			"git::https://github.com/hashicorp/foo.git?foo=bar",
+		},
+	}
+
+	f := new(GitHubDetector)
+	for i, tc := range cases {
+		output, ok, err := f.Detect(tc.Input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if !ok {
+			t.Fatal("not ok")
+		}
+
+		if output != tc.Output {
+			t.Fatalf("%d: bad: %#v", i, output)
+		}
+	}
+}

--- a/internal/detect/detect_s3.go
+++ b/internal/detect/detect_s3.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// S3Detector implements Detector to detect S3 URLs and turn
+// them into URLs that the S3 getter can understand.
+type S3Detector struct{}
+
+func (d *S3Detector) Detect(src string) (string, bool, error) {
+	if len(src) == 0 {
+		return "", false, nil
+	}
+
+	if strings.Contains(src, ".amazonaws.com/") {
+		return d.detectHTTP(src)
+	}
+
+	return "", false, nil
+}
+
+func (d *S3Detector) detectHTTP(src string) (string, bool, error) {
+	parts := strings.Split(src, "/")
+	if len(parts) < 2 {
+		return "", false, fmt.Errorf(
+			"URL is not a valid S3 URL")
+	}
+
+	hostParts := strings.Split(parts[0], ".")
+	if len(hostParts) == 3 {
+		return d.detectPathStyle(hostParts[0], parts[1:])
+	} else if len(hostParts) == 4 {
+		return d.detectVhostStyle(hostParts[1], hostParts[0], parts[1:])
+	} else if len(hostParts) == 5 && hostParts[1] == "s3" {
+		return d.detectNewVhostStyle(hostParts[2], hostParts[0], parts[1:])
+	} else {
+		return "", false, fmt.Errorf(
+			"URL is not a valid S3 URL")
+	}
+}
+
+func (d *S3Detector) detectPathStyle(region string, parts []string) (string, bool, error) {
+	urlStr := fmt.Sprintf("https://%s.amazonaws.com/%s", region, strings.Join(parts, "/"))
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return "", false, fmt.Errorf("error parsing S3 URL: %s", err)
+	}
+
+	return "s3::" + url.String(), true, nil
+}
+
+func (d *S3Detector) detectVhostStyle(region, bucket string, parts []string) (string, bool, error) {
+	urlStr := fmt.Sprintf("https://%s.amazonaws.com/%s/%s", region, bucket, strings.Join(parts, "/"))
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return "", false, fmt.Errorf("error parsing S3 URL: %s", err)
+	}
+
+	return "s3::" + url.String(), true, nil
+}
+
+func (d *S3Detector) detectNewVhostStyle(region, bucket string, parts []string) (string, bool, error) {
+	urlStr := fmt.Sprintf("https://s3.%s.amazonaws.com/%s/%s", region, bucket, strings.Join(parts, "/"))
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return "", false, fmt.Errorf("error parsing S3 URL: %s", err)
+	}
+
+	return "s3::" + url.String(), true, nil
+}

--- a/internal/detect/detect_s3_test.go
+++ b/internal/detect/detect_s3_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"testing"
+)
+
+func TestS3Detector(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		// Virtual hosted style
+		{
+			"bucket.s3.amazonaws.com/foo",
+			"s3::https://s3.amazonaws.com/bucket/foo",
+		},
+		{
+			"bucket.s3.amazonaws.com/foo/bar",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"bucket.s3.amazonaws.com/foo/bar.baz",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar.baz",
+		},
+		{
+			"bucket.s3-eu-west-1.amazonaws.com/foo",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo",
+		},
+		{
+			"bucket.s3-eu-west-1.amazonaws.com/foo/bar",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"bucket.s3-eu-west-1.amazonaws.com/foo/bar.baz",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+		},
+		// 5 parts Virtual hosted-style
+		{
+			"bucket.s3.eu-west-1.amazonaws.com/foo/bar.baz",
+			"s3::https://s3.eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+		},
+		// Path style
+		{
+			"s3.amazonaws.com/bucket/foo",
+			"s3::https://s3.amazonaws.com/bucket/foo",
+		},
+		{
+			"s3.amazonaws.com/bucket/foo/bar",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"s3.amazonaws.com/bucket/foo/bar.baz",
+			"s3::https://s3.amazonaws.com/bucket/foo/bar.baz",
+		},
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo",
+		},
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo/bar",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar",
+		},
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz",
+		},
+		// Misc tests
+		{
+			"s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
+			"s3::https://s3-eu-west-1.amazonaws.com/bucket/foo/bar.baz?version=1234",
+		},
+	}
+
+	f := new(S3Detector)
+	for i, tc := range cases {
+		output, ok, err := f.Detect(tc.Input)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if !ok {
+			t.Fatal("not ok")
+		}
+
+		if output != tc.Output {
+			t.Fatalf("%d: bad: %#v", i, output)
+		}
+	}
+}

--- a/internal/detect/detect_ssh.go
+++ b/internal/detect/detect_ssh.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Note that we do not have an SSH-getter currently so this file serves
+// only to hold the detectSSH helper that is used by other detectors.
+
+// sshPattern matches SCP-like SSH patterns (user@host:path)
+var sshPattern = regexp.MustCompile("^(?:([^@]+)@)?([^:]+):/?(.+)$")
+
+// detectSSH determines if the src string matches an SSH-like URL and
+// converts it into a net.URL compatible string. This returns nil if the
+// string doesn't match the SSH pattern.
+//
+// This function is tested indirectly via detect_git_test.go
+func detectSSH(src string) (*url.URL, error) {
+	matched := sshPattern.FindStringSubmatch(src)
+	if matched == nil {
+		return nil, nil
+	}
+
+	user := matched[1]
+	host := matched[2]
+	path := matched[3]
+	qidx := strings.Index(path, "?")
+	if qidx == -1 {
+		qidx = len(path)
+	}
+
+	var u url.URL
+	u.Scheme = "ssh"
+	u.User = url.User(user)
+	u.Host = host
+	u.Path = path[0:qidx]
+	if qidx < len(path) {
+		q, err := url.ParseQuery(path[qidx+1:])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing GitHub SSH URL: %s", err)
+		}
+		u.RawQuery = q.Encode()
+	}
+
+	return &u, nil
+}

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+		Err    bool
+	}{
+		{
+
+			"git::github.com/hashicorp/foo",
+			"git::https://github.com/hashicorp/foo.git",
+			false,
+		},
+		{
+			"git::github.com/hashicorp/foo//bar",
+			"git::https://github.com/hashicorp/foo.git//bar",
+			false,
+		},
+		{
+			"git::https://github.com/hashicorp/consul.git",
+			"git::https://github.com/hashicorp/consul.git",
+			false,
+		},
+		{
+			"git::https://person@someothergit.com/foo/bar",
+			"git::https://person@someothergit.com/foo/bar",
+			false,
+		},
+		{
+			"git::https://person@someothergit.com/foo/bar",
+			"git::https://person@someothergit.com/foo/bar",
+			false,
+		},
+		{
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			false,
+		},
+		{
+			"git::git@my.custom.git:dir1/dir2",
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			false,
+		},
+		{
+			"git::git@my.custom.git:dir1/dir2",
+			"git::ssh://git@my.custom.git/dir1/dir2",
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d %s", i, tc.Input), func(t *testing.T) {
+			output, err := Detect(tc.Input, RemoteSourceDetectors)
+			if err != nil != tc.Err {
+				t.Fatalf("%d: bad err: %s", i, err)
+			}
+			if output != tc.Output {
+				t.Fatalf("%d: bad output: %s\nexpected: %s", i, output, tc.Output)
+			}
+		})
+	}
+}

--- a/internal/detect/get.go
+++ b/internal/detect/get.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import "regexp"
+
+// forcedRegexp is the regular expression that finds forced getters. This
+// syntax is schema::url, example: git::https://foo.com
+var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
+
+// getForcedGetter takes a source and returns the tuple of the forced
+// getter and the raw URL (without the force syntax).
+func getForcedGetter(src string) (string, string) {
+	var forced string
+	if ms := forcedRegexp.FindStringSubmatch(src); ms != nil {
+		forced = ms[1]
+		src = ms[2]
+	}
+
+	return forced, src
+}

--- a/internal/detect/source.go
+++ b/internal/detect/source.go
@@ -1,0 +1,80 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// SourceDirSubdir takes a source URL and returns a tuple of the URL without
+// the subdir and the subdir.
+//
+// ex:
+//
+//	dom.com/path/?q=p               => dom.com/path/?q=p, ""
+//	proto://dom.com/path//*?q=p     => proto://dom.com/path?q=p, "*"
+//	proto://dom.com/path//path2?q=p => proto://dom.com/path?q=p, "path2"
+func SourceDirSubdir(src string) (string, string) {
+
+	// URL might contains another url in query parameters
+	stop := len(src)
+	if idx := strings.Index(src, "?"); idx > -1 {
+		stop = idx
+	}
+
+	// Calculate an offset to avoid accidentally marking the scheme
+	// as the dir.
+	var offset int
+	if idx := strings.Index(src[:stop], "://"); idx > -1 {
+		offset = idx + 3
+	}
+
+	// First see if we even have an explicit subdir
+	idx := strings.Index(src[offset:stop], "//")
+	if idx == -1 {
+		return src, ""
+	}
+
+	idx += offset
+	subdir := src[idx+2:]
+	src = src[:idx]
+
+	// Next, check if we have query parameters and push them onto the
+	// URL.
+	if idx = strings.Index(subdir, "?"); idx > -1 {
+		query := subdir[idx:]
+		subdir = subdir[:idx]
+		src += query
+	}
+
+	return src, subdir
+}
+
+// SubdirGlob returns the actual subdir with globbing processed.
+//
+// dst should be a destination directory that is already populated (the
+// download is complete) and subDir should be the set subDir. If subDir
+// is an empty string, this returns an empty string.
+//
+// The returned path is the full absolute path.
+func SubdirGlob(dst, subDir string) (string, error) {
+	pattern := filepath.Join(dst, subDir)
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("subdir %q not found", subDir)
+	}
+
+	if len(matches) > 1 {
+		return "", fmt.Errorf("subdir %q matches multiple paths", subDir)
+	}
+
+	return matches[0], nil
+}

--- a/internal/detect/source_test.go
+++ b/internal/detect/source_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package detect
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSourceDirSubdir(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Dir, Sub string
+	}{
+		{
+			"hashicorp.com",
+			"hashicorp.com", "",
+		},
+		{
+			"hashicorp.com//foo",
+			"hashicorp.com", "foo",
+		},
+		{
+			"hashicorp.com//foo?bar=baz",
+			"hashicorp.com?bar=baz", "foo",
+		},
+		{
+			"https://hashicorp.com/path//*?archive=foo",
+			"https://hashicorp.com/path?archive=foo", "*",
+		},
+		{
+			"https://hashicorp.com/path?checksum=file:http://url.com/....iso.sha256",
+			"https://hashicorp.com/path?checksum=file:http://url.com/....iso.sha256", "",
+		},
+		{
+			"https://hashicorp.com/path//*?checksum=file:http://url.com/....iso.sha256",
+			"https://hashicorp.com/path?checksum=file:http://url.com/....iso.sha256", "*",
+		},
+		{
+			"file://foo//bar",
+			"file://foo", "bar",
+		},
+	}
+
+	for i, tc := range cases {
+		adir, asub := SourceDirSubdir(tc.Input)
+		if adir != tc.Dir {
+			t.Fatalf("%d: bad dir: %#v", i, adir)
+		}
+		if asub != tc.Sub {
+			t.Fatalf("%d: bad sub: %#v", i, asub)
+		}
+	}
+}
+
+func TestSourceSubdirGlob(t *testing.T) {
+	td, err := ioutil.TempDir("", "subdir-glob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(td)
+
+	if err := os.Mkdir(filepath.Join(td, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Mkdir(filepath.Join(td, "subdir/one"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Mkdir(filepath.Join(td, "subdir/two"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	subdir := filepath.Join(td, "subdir")
+
+	// match the exact directory
+	res, err := SubdirGlob(td, "subdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != subdir {
+		t.Fatalf(`expected "subdir", got: %q`, subdir)
+	}
+
+	// single match from a wildcard
+	res, err = SubdirGlob(td, "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != subdir {
+		t.Fatalf(`expected "subdir", got: %q`, subdir)
+	}
+
+	// multiple matches
+	res, err = SubdirGlob(td, "subdir/*")
+	if err == nil {
+		t.Fatalf("expected multiple matches, got %q", res)
+	}
+
+	// non-existent
+	res, err = SubdirGlob(td, "foo")
+	if err == nil {
+		t.Fatalf("expected no matches, got %q", res)
+	}
+}

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -31,11 +31,12 @@ type InstalledModuleCall struct {
 }
 
 type DeclaredModuleCall struct {
-	LocalName  string
-	SourceAddr ModuleSourceAddr
-	Version    version.Constraints
-	InputNames []string
-	RangePtr   *hcl.Range
+	LocalName     string
+	RawSourceAddr string
+	SourceAddr    ModuleSourceAddr
+	Version       version.Constraints
+	InputNames    []string
+	RangePtr      *hcl.Range
 }
 
 func (mc DeclaredModuleCall) Copy() DeclaredModuleCall {
@@ -43,10 +44,11 @@ func (mc DeclaredModuleCall) Copy() DeclaredModuleCall {
 	copy(inputNames, mc.InputNames)
 
 	newModuleCall := DeclaredModuleCall{
-		LocalName:  mc.LocalName,
-		SourceAddr: mc.SourceAddr,
-		Version:    mc.Version,
-		InputNames: inputNames,
+		LocalName:     mc.LocalName,
+		RawSourceAddr: mc.RawSourceAddr,
+		SourceAddr:    mc.SourceAddr,
+		Version:       mc.Version,
+		InputNames:    inputNames,
 	}
 
 	if mc.RangePtr != nil {

--- a/module/module_calls.go
+++ b/module/module_calls.go
@@ -105,7 +105,7 @@ func ParseModuleSourceAddr(source string) ModuleSourceAddr {
 		sourceAddr = registryAddr
 	} else if isModuleSourceLocal(source) {
 		sourceAddr = LocalSourceAddr(source)
-	} else if remoteAddr, err := isRemoteModuleSource(source); err == nil {
+	} else if remoteAddr, err := parseRemoteModuleSource(source); err == nil {
 		sourceAddr = RemoteSourceAddr(remoteAddr)
 	} else if source != "" {
 		sourceAddr = UnknownSourceAddr(source)
@@ -123,6 +123,6 @@ func isModuleSourceLocal(raw string) bool {
 	return false
 }
 
-func isRemoteModuleSource(raw string) (string, error) {
+func parseRemoteModuleSource(raw string) (string, error) {
 	return detect.Detect(raw, detect.RemoteSourceDetectors)
 }

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -17,7 +17,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func schemaForDeclaredDependentModuleBlock(module module.DeclaredModuleCall, modMeta *registry.ModuleData) (*schema.BodySchema, error) {
+func schemaForDependentRegistryModuleBlock(module module.DeclaredModuleCall, modMeta *registry.ModuleData) (*schema.BodySchema, error) {
 	attributes := make(map[string]*schema.AttributeSchema, 0)
 
 	for _, input := range modMeta.Inputs {
@@ -105,7 +105,7 @@ func schemaForDeclaredDependentModuleBlock(module module.DeclaredModuleCall, mod
 	return bodySchema, nil
 }
 
-func schemaForDependentModuleBlock(module module.InstalledModuleCall, modMeta *module.Meta) (*schema.BodySchema, error) {
+func schemaForDependentModuleBlock(module module.DeclaredModuleCall, modMeta *module.Meta) (*schema.BodySchema, error) {
 	attributes := make(map[string]*schema.AttributeSchema, 0)
 
 	for name, modVar := range modMeta.Variables {

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSchemaForDependentModuleBlock_emptyMeta(t *testing.T) {
 	meta := &module.Meta{}
-	module := module.InstalledModuleCall{
+	module := module.DeclaredModuleCall{
 		LocalName: "refname",
 	}
 	depSchema, err := schemaForDependentModuleBlock(module, meta)
@@ -74,7 +74,7 @@ func TestSchemaForDependentModuleBlock_basic(t *testing.T) {
 			},
 		},
 	}
-	module := module.InstalledModuleCall{
+	module := module.DeclaredModuleCall{
 		LocalName: "refname",
 	}
 	depSchema, err := schemaForDependentModuleBlock(module, meta)
@@ -307,7 +307,7 @@ func TestSchemaForDependentModuleBlock_Target(t *testing.T) {
 			},
 		},
 	}
-	module := module.InstalledModuleCall{
+	module := module.DeclaredModuleCall{
 		LocalName: "refname",
 	}
 
@@ -326,7 +326,7 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 	type testCase struct {
 		name           string
 		meta           *module.Meta
-		module         module.InstalledModuleCall
+		module         module.DeclaredModuleCall
 		expectedSchema *schema.BodySchema
 	}
 
@@ -339,7 +339,7 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				Outputs:   map[string]module.Output{},
 				Filenames: nil,
 			},
-			module.InstalledModuleCall{
+			module.DeclaredModuleCall{
 				LocalName:  "refname",
 				SourceAddr: module.LocalSourceAddr("./local"),
 			},
@@ -368,7 +368,7 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				Outputs:   map[string]module.Output{},
 				Filenames: nil,
 			},
-			module.InstalledModuleCall{
+			module.DeclaredModuleCall{
 				LocalName:  "vpc",
 				SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
 			},
@@ -399,10 +399,10 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				Outputs:   map[string]module.Output{},
 				Filenames: nil,
 			},
-			module.InstalledModuleCall{
+			module.DeclaredModuleCall{
 				LocalName:  "vpc",
 				SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/terraform-aws-modules/vpc/aws"),
-				Version:    version.Must(version.NewVersion("1.33.7")),
+				Version:    version.MustConstraints(version.NewConstraint("1.33.7")),
 			},
 			&schema.BodySchema{
 				Attributes: map[string]*schema.AttributeSchema{},
@@ -431,10 +431,10 @@ func TestSchemaForDependentModuleBlock_DocsLink(t *testing.T) {
 				Outputs:   map[string]module.Output{},
 				Filenames: nil,
 			},
-			module.InstalledModuleCall{
+			module.DeclaredModuleCall{
 				LocalName:  "vpc",
 				SourceAddr: tfaddr.MustParseModuleSource("example.com/terraform-aws-modules/vpc/aws"),
-				Version:    version.Must(version.NewVersion("1.33.7")),
+				Version:    version.MustConstraints(version.NewConstraint("1.33.7")),
 			},
 			&schema.BodySchema{
 				Attributes: map[string]*schema.AttributeSchema{},
@@ -500,7 +500,7 @@ func TestSchemaForDeclaredDependentModuleBlock_basic(t *testing.T) {
 		LocalName:  "refname",
 		SourceAddr: tfaddr.MustParseModuleSource("terraform-aws-modules/eks/aws"),
 	}
-	depSchema, err := schemaForDeclaredDependentModuleBlock(module, meta)
+	depSchema, err := schemaForDependentRegistryModuleBlock(module, meta)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -242,13 +242,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 
 				modMeta, err := m.stateReader.LocalModuleMeta(path)
 				if err == nil {
-					// We're creating a InstalledModuleCall here, because we need one to call schemaForDependentModuleBlock
-					// TODO revisit and refactor this
-					fakeMod := tfmod.InstalledModuleCall{
-						LocalName:  module.LocalName,
-						SourceAddr: module.SourceAddr,
-					}
-					depSchema, err := schemaForDependentModuleBlock(fakeMod, modMeta)
+					depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 					if err == nil {
 						mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 					}
@@ -264,7 +258,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 				continue
 			}
 
-			depSchema, err := schemaForDeclaredDependentModuleBlock(module, modMeta)
+			depSchema, err := schemaForDependentRegistryModuleBlock(module, modMeta)
 			if err == nil {
 				mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 			}
@@ -278,13 +272,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 
 			modMeta, err := m.stateReader.LocalModuleMeta(path)
 			if err == nil {
-				// We're creating a InstalledModuleCall here, because we need one to call schemaForDependentModuleBlock
-				// TODO revisit and refactor this
-				fakeMod := tfmod.InstalledModuleCall{
-					LocalName:  module.LocalName,
-					SourceAddr: module.SourceAddr,
-				}
-				depSchema, err := schemaForDependentModuleBlock(fakeMod, modMeta)
+				depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 				if err == nil {
 					mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 				}
@@ -295,13 +283,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 
 			modMeta, err := m.stateReader.LocalModuleMeta(path)
 			if err == nil {
-				// We're creating a InstalledModuleCall here, because we need one to call schemaForDependentModuleBlock
-				// TODO revisit and refactor this
-				fakeMod := tfmod.InstalledModuleCall{
-					LocalName:  module.LocalName,
-					SourceAddr: module.SourceAddr,
-				}
-				depSchema, err := schemaForDependentModuleBlock(fakeMod, modMeta)
+				depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 				if err == nil {
 					mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
 				}

--- a/schema/schema_merge_test.go
+++ b/schema/schema_merge_test.go
@@ -537,6 +537,10 @@ func (sr *exactSchemaReader) LocalModuleMeta(modPath string) (*module.Meta, erro
 	return nil, nil
 }
 
+func (m *exactSchemaReader) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
+}
+
 func TestMergeWithJsonProviderSchemas_v015(t *testing.T) {
 	sm := NewSchemaMerger(testCoreSchema())
 	sr := testSchemaReader(t, filepath.Join("testdata", "provider-schemas-0.15.json"), false, false)
@@ -675,8 +679,9 @@ func (m *testJsonSchemaReader) DeclaredModuleCalls(modPath string) (map[string]m
 
 	return map[string]module.DeclaredModuleCall{
 		"example": {
-			LocalName:  "example",
-			SourceAddr: module.LocalSourceAddr("./source"),
+			LocalName:     "example",
+			RawSourceAddr: "./source",
+			SourceAddr:    module.LocalSourceAddr("./source"),
 		},
 	}, nil
 }
@@ -704,6 +709,10 @@ func (m *testJsonSchemaReader) LocalModuleMeta(modPath string) (*module.Meta, er
 	return nil, fmt.Errorf("invalid source")
 }
 
+func (m *testJsonSchemaReader) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
+}
+
 func testModuleStateReader() StateReader {
 	return &testModuleReaderStruct{}
 }
@@ -718,8 +727,9 @@ func (m *testModuleReaderStruct) RegistryModuleMeta(addr tfaddr.Module, cons ver
 func (m *testModuleReaderStruct) DeclaredModuleCalls(modPath string) (map[string]module.DeclaredModuleCall, error) {
 	return map[string]module.DeclaredModuleCall{
 		"example": {
-			LocalName:  "example",
-			SourceAddr: module.LocalSourceAddr("./source"),
+			LocalName:     "example",
+			RawSourceAddr: "./source",
+			SourceAddr:    module.LocalSourceAddr("./source"),
 		},
 	}, nil
 }
@@ -745,6 +755,10 @@ func (m *testModuleReaderStruct) LocalModuleMeta(modPath string) (*module.Meta, 
 
 func (r *testModuleReaderStruct) ProviderSchema(_ string, pAddr tfaddr.Provider, _ version.Constraints) (*ProviderSchema, error) {
 	return nil, nil
+}
+
+func (m *testModuleReaderStruct) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
 }
 
 func testRegistryStateReader() StateReader {
@@ -785,6 +799,10 @@ func (m *testRegistryModuleReaderStruct) LocalModuleMeta(modPath string) (*modul
 		}, nil
 	}
 	return nil, fmt.Errorf("invalid source")
+}
+
+func (m *testRegistryModuleReaderStruct) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
 }
 
 func (r *testRegistryModuleReaderStruct) ProviderSchema(_ string, pAddr tfaddr.Provider, _ version.Constraints) (*ProviderSchema, error) {

--- a/schema/schema_merge_test.go
+++ b/schema/schema_merge_test.go
@@ -713,54 +713,6 @@ func (m *testJsonSchemaReader) InstalledModulePath(rootPath string, normalizedSo
 	return "", false
 }
 
-func testModuleStateReader() StateReader {
-	return &testModuleReaderStruct{}
-}
-
-type testModuleReaderStruct struct {
-}
-
-func (m *testModuleReaderStruct) RegistryModuleMeta(addr tfaddr.Module, cons version.Constraints) (*registry.ModuleData, error) {
-	return nil, nil
-}
-
-func (m *testModuleReaderStruct) DeclaredModuleCalls(modPath string) (map[string]module.DeclaredModuleCall, error) {
-	return map[string]module.DeclaredModuleCall{
-		"example": {
-			LocalName:     "example",
-			RawSourceAddr: "./source",
-			SourceAddr:    module.LocalSourceAddr("./source"),
-		},
-	}, nil
-}
-
-func (m *testModuleReaderStruct) InstalledModuleCalls(modPath string) (map[string]module.InstalledModuleCall, error) {
-	return nil, nil
-}
-
-func (m *testModuleReaderStruct) LocalModuleMeta(modPath string) (*module.Meta, error) {
-	if modPath == filepath.Join("testdata", "source") {
-		return &module.Meta{
-			Path: "path",
-			Variables: map[string]module.Variable{
-				"test": {
-					Type:        cty.String,
-					Description: "test var",
-				},
-			},
-		}, nil
-	}
-	return nil, fmt.Errorf("invalid source")
-}
-
-func (r *testModuleReaderStruct) ProviderSchema(_ string, pAddr tfaddr.Provider, _ version.Constraints) (*ProviderSchema, error) {
-	return nil, nil
-}
-
-func (m *testModuleReaderStruct) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
-	return "", false
-}
-
 func testRegistryStateReader() StateReader {
 	return &testRegistryModuleReaderStruct{}
 }
@@ -773,21 +725,17 @@ func (m *testRegistryModuleReaderStruct) RegistryModuleMeta(addr tfaddr.Module, 
 }
 
 func (m *testRegistryModuleReaderStruct) DeclaredModuleCalls(modPath string) (map[string]module.DeclaredModuleCall, error) {
-	return nil, nil
-}
-
-func (m *testRegistryModuleReaderStruct) InstalledModuleCalls(modPath string) (map[string]module.InstalledModuleCall, error) {
-	return map[string]module.InstalledModuleCall{
+	return map[string]module.DeclaredModuleCall{
 		"remote-example": {
-			LocalName:  "remote-example",
-			SourceAddr: tfaddr.MustParseModuleSource("registry.terraform.io/namespace/foo/bar"),
-			Path:       ".terraform/modules/remote-example",
+			LocalName:     "remote-example",
+			RawSourceAddr: "namespace/foo/bar",
+			SourceAddr:    tfaddr.MustParseModuleSource("registry.terraform.io/namespace/foo/bar"),
 		},
 	}, nil
 }
 
 func (m *testRegistryModuleReaderStruct) LocalModuleMeta(modPath string) (*module.Meta, error) {
-	if modPath == ".terraform/modules/remote-example" {
+	if modPath == "testdata/.terraform/modules/remote-example" {
 		return &module.Meta{
 			Path: ".terraform/modules/remote-example",
 			Variables: map[string]module.Variable{
@@ -802,6 +750,9 @@ func (m *testRegistryModuleReaderStruct) LocalModuleMeta(modPath string) (*modul
 }
 
 func (m *testRegistryModuleReaderStruct) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	if normalizedSource == "registry.terraform.io/namespace/foo/bar" {
+		return ".terraform/modules/remote-example", true
+	}
 	return "", false
 }
 

--- a/schema/schema_merge_v015_test.go
+++ b/schema/schema_merge_v015_test.go
@@ -545,49 +545,5 @@ var expectedRemoteModuleSchema = &schema.BlockSchema{
 				},
 			},
 		},
-		schema.NewSchemaKey(schema.DependencyKeys{
-			Attributes: []schema.AttributeDependent{
-				{
-					Name: "source",
-					Expr: schema.ExpressionValue{
-						Static: cty.StringVal("registry.terraform.io/namespace/foo/bar"),
-					},
-				},
-			}}): {
-			TargetableAs: []*schema.Targetable{
-				{
-					Address: lang.Address{
-						lang.RootStep{Name: "module"},
-						lang.AttrStep{Name: "remote-example"},
-					},
-					ScopeId:           refscope.ModuleScope,
-					AsType:            cty.Object(map[string]cty.Type{}),
-					NestedTargetables: []*schema.Targetable{},
-				},
-			},
-			ImpliedOrigins: schema.ImpliedOrigins{},
-			DocsLink:       &schema.DocsLink{URL: "https://registry.terraform.io/modules/namespace/foo/bar/latest"},
-			Attributes: map[string]*schema.AttributeSchema{
-				"test": {
-					Description: lang.PlainText("test var"),
-					Constraint:  schema.AnyExpression{OfType: cty.String},
-					IsRequired:  true,
-					OriginForTarget: &schema.PathTarget{
-						Address: schema.Address{
-							schema.StaticStep{Name: "var"},
-							schema.AttrNameStep{},
-						},
-						Path: lang.Path{
-							Path:       ".terraform/modules/remote-example",
-							LanguageID: "terraform",
-						},
-						Constraints: schema.Constraints{
-							ScopeId: "variable",
-							Type:    cty.String,
-						},
-					},
-				},
-			},
-		},
 	},
 }

--- a/schema/testdata/test-config-0.15.tf
+++ b/schema/testdata/test-config-0.15.tf
@@ -7,6 +7,6 @@ terraform {
   }
 }
 
-module "test" {
-  source = "source"
+module "example" {
+  source = "./source"
 }

--- a/schema/testdata/test-config-remote-module.tf
+++ b/schema/testdata/test-config-remote-module.tf
@@ -1,3 +1,3 @@
 module "remote-example" {
-  source = "namespace/foobar"
+  source = "namespace/foo/bar"
 }


### PR DESCRIPTION
* Part of https://github.com/hashicorp/terraform-ls/pull/1760

---

This PR introduces support for remote module sources and changes the module schema merging logic.

The new `detect` package is based on same go-getter detection logic that Terraform uses to identify module source addresses. The separate type for remote module sources  allows us to identify these when merging the schema and decoding the declared module blocks. With that we can provide schemas for all installed remote modules.

When merging the schema for module blocks, we can now support different module sources:
1. Registry modules can have a schema from a local installation or fetched from the registry
2. Remote modules can have a schema from a local installation. All kind of remote modules sources are supported now.
3. Local modules will use the schema from the local module path

Since we now use the raw module source as dependency key for the dependent bodies, we don't have to add multiple keys for potential multiple different source formats. Furthermore, using the normalized source address for looking up the schema in state, should remove any ambiguity.

## UX

see https://github.com/hashicorp/terraform-ls/pull/1760