### PR TITLE
Rename `variables` to `inputs` for Stack deployments

### DIFF
--- a/internal/schema/stacks/1.9/deployment_block.go
+++ b/internal/schema/stacks/1.9/deployment_block.go
@@ -17,7 +17,7 @@ func deploymentBlockSchema() *schema.BlockSchema {
 			{
 				Name:                   "name",
 				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name, lang.TokenModifierDependent},
-				Description:            lang.PlainText("Deplyoment Name"),
+				Description:            lang.PlainText("Deployment Name"),
 				IsDepKey:               true,
 				Completable:            true,
 			},
@@ -27,7 +27,7 @@ func deploymentBlockSchema() *schema.BlockSchema {
 				DynamicBlocks: true,
 			},
 			Attributes: map[string]*schema.AttributeSchema{
-				"variables": {
+				"inputs": {
 					Description: lang.Markdown("A mapping of stack variable names to values for this deployment. The keys of this map must correspond to the names of variables defined for the stack. The values must be valid HCL literals meeting the type constraint of those variables. Values are also expressions, currently with access to identity token references only"),
 					IsOptional:  true,
 					Constraint: schema.Map{


### PR DESCRIPTION
This was recently renamed in the agent.