### PR TITLE
(TF-18292) Parse Module source address from the stack file

### DIFF
--- a/earlydecoder/stacks/decoder_test.go
+++ b/earlydecoder/stacks/decoder_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	tfaddr "github.com/hashicorp/terraform-registry-address"
+	"github.com/hashicorp/terraform-schema/module"
 	"github.com/hashicorp/terraform-schema/stack"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 )
@@ -55,9 +56,15 @@ func TestLoadStack(t *testing.T) {
 	}
 }`,
 			&stack.Meta{
-				Path:                 path,
-				Filenames:            []string{"test.tf"},
-				Components:           map[string]stack.Component{"test": {Source: "github.com/acme/infra/core", Version: version.MustConstraints(version.NewConstraint(">= 1.0, < 2.0"))}},
+				Path:      path,
+				Filenames: []string{"test.tf"},
+				Components: map[string]stack.Component{
+					"test": {
+						Source:     "github.com/acme/infra/core",
+						SourceAddr: module.ParseModuleSourceAddr("git::https://github.com/acme/infra.git//core"),
+						Version:    version.MustConstraints(version.NewConstraint(">= 1.0, < 2.0")),
+					},
+				},
 				Variables:            map[string]stack.Variable{},
 				Outputs:              map[string]stack.Output{},
 				ProviderRequirements: map[string]stack.ProviderRequirement{},

--- a/earlydecoder/stacks/load_stack.go
+++ b/earlydecoder/stacks/load_stack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/terraform-schema/module"
 	"github.com/hashicorp/terraform-schema/stack"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -74,8 +75,9 @@ func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
 			}
 
 			ds.Components[name] = &stack.Component{
-				Source:  source,
-				Version: versionCons,
+				Source:     source,
+				SourceAddr: module.ParseModuleSourceAddr(source),
+				Version:    versionCons,
 			}
 		case "provider":
 			// there is no point to parsing provider blocks here, as they need the full

--- a/stack/component.go
+++ b/stack/component.go
@@ -3,9 +3,13 @@
 
 package stack
 
-import "github.com/hashicorp/go-version"
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-schema/module"
+)
 
 type Component struct {
-	Source  string
-	Version version.Constraints
+	Source     string
+	SourceAddr module.ModuleSourceAddr
+	Version    version.Constraints
 }


### PR DESCRIPTION
This commit adds the ability to parse the module source address from the stack file. This is useful for detecting the type of module that is being referenced.
