### PR TITLE
feat: parse provider requirements and return constraint and version instead of raw strings

### DIFF
--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -58,18 +58,14 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagno
 			continue
 		}
 
-		constraints := make(version.Constraints, 0)
-		for _, vc := range req.VersionConstraints {
-			c, err := version.NewConstraint(vc)
-			if err != nil {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
-					Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", vc, err),
-				})
-				continue
-			}
-			constraints = append(constraints, c...)
+		constraints, err := version.NewConstraint(req.VersionConstraints)
+		if err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
+				Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", req.VersionConstraints, err),
+			})
+			continue
 		}
 
 		providerRequirements[name] = stack.ProviderRequirement{

--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -4,10 +4,14 @@
 package earlydecoder
 
 import (
+	"fmt"
 	"sort"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-schema/stack"
+
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 )
 
 func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagnostics) {
@@ -39,11 +43,38 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagno
 		outputs[key] = *output
 	}
 
-	providerRequirements := make(map[string]stack.ProviderRequirement)
-	for key, providerRequirement := range mod.ProviderRequirements {
-		providerRequirements[key] = stack.ProviderRequirement{
-			Source:             providerRequirement.Source,
-			VersionConstraints: providerRequirement.VersionConstraints,
+	var providerRequirements = make(map[string]stack.ProviderRequirement, 0)
+	for name, req := range mod.ProviderRequirements {
+		var src tfaddr.Provider
+
+		var err error
+		src, err = tfaddr.ParseProviderSource(req.Source)
+		if err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Unable to parse provider source for %q", name),
+				Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, req.Source),
+			})
+			continue
+		}
+
+		constraints := make(version.Constraints, 0)
+		for _, vc := range req.VersionConstraints {
+			c, err := version.NewConstraint(vc)
+			if err != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
+					Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", vc, err),
+				})
+				continue
+			}
+			constraints = append(constraints, c...)
+		}
+
+		providerRequirements[name] = stack.ProviderRequirement{
+			Source:             src,
+			VersionConstraints: constraints,
 		}
 	}
 

--- a/earlydecoder/stacks/decoder_test.go
+++ b/earlydecoder/stacks/decoder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform-schema/stack"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 )
@@ -82,8 +83,8 @@ func TestLoadStack(t *testing.T) {
 				Variables:  map[string]stack.Variable{},
 				Outputs:    map[string]stack.Output{},
 				ProviderRequirements: map[string]stack.ProviderRequirement{
-					"aws":    {Source: "hashicorp/aws", VersionConstraints: []string{"~> 5.7.0"}},
-					"random": {Source: "hashicorp/random", VersionConstraints: []string{"~> 3.5.1"}},
+					"aws":    {Source: tfaddr.MustParseProviderSource("hashicorp/aws"), VersionConstraints: version.MustConstraints(version.NewConstraint("~> 5.7.0"))},
+					"random": {Source: tfaddr.MustParseProviderSource("hashicorp/random"), VersionConstraints: version.MustConstraints(version.NewConstraint("~> 3.5.1"))},
 				},
 			},
 			nil,

--- a/earlydecoder/stacks/load_stack.go
+++ b/earlydecoder/stacks/load_stack.go
@@ -101,7 +101,19 @@ func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
 						}
 					}
 
-					ds.ProviderRequirements[name].VersionConstraints = append(ds.ProviderRequirements[name].VersionConstraints, req.VersionConstraints...)
+					if req.VersionConstraints != "" {
+						existingVersionConstraints := ds.ProviderRequirements[name].VersionConstraints
+						if existingVersionConstraints != "" && existingVersionConstraints != req.VersionConstraints {
+							diags = append(diags, &hcl.Diagnostic{
+								Severity: hcl.DiagError,
+								Summary:  "Multiple provider version constraints",
+								Detail:   fmt.Sprintf("Found multiple version constraints for provider %s: %q, %q", name, existingVersionConstraints, req.VersionConstraints),
+								Subject:  &block.DefRange,
+							})
+						} else {
+							ds.ProviderRequirements[name].VersionConstraints = req.VersionConstraints
+						}
+					}
 				}
 			}
 		case "variable":

--- a/earlydecoder/stacks/provider_requirements.go
+++ b/earlydecoder/stacks/provider_requirements.go
@@ -12,7 +12,7 @@ import (
 
 type providerRequirement struct {
 	Source             string
-	VersionConstraints []string
+	VersionConstraints string
 }
 
 func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequirement, hcl.Diagnostics) {
@@ -62,7 +62,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 					continue
 				}
 				if !version.IsNull() {
-					pr.VersionConstraints = append(pr.VersionConstraints, version.AsString())
+					pr.VersionConstraints = version.AsString()
 				}
 
 			case "source":

--- a/stack/provider_requirements.go
+++ b/stack/provider_requirements.go
@@ -3,7 +3,12 @@
 
 package stack
 
+import (
+	"github.com/hashicorp/go-version"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
 type ProviderRequirement struct {
-	Source             string
-	VersionConstraints []string
+	Source             tfaddr.Provider
+	VersionConstraints version.Constraints
 }


### PR DESCRIPTION
This PR is required for https://github.com/hashicorp/terraform-ls/pull/1763

It changes the types of the parsed provider address and version constraints from a raw string to their respective types.