### PR TITLE
feat: add schema merger for deployment files

### DIFF
--- a/earlydecoder/stacks/load_stack.go
+++ b/earlydecoder/stacks/load_stack.go
@@ -129,10 +129,16 @@ func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
 
 			name := block.Labels[0]
 			description := ""
+			isSensitive := false
 			var valDiags hcl.Diagnostics
 
 			if attr, defined := content.Attributes["description"]; defined {
 				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &description)
+				diags = append(diags, valDiags...)
+			}
+
+			if attr, defined := content.Attributes["sensitive"]; defined {
+				valDiags = gohcl.DecodeExpression(attr.Expr, nil, &isSensitive)
 				diags = append(diags, valDiags...)
 			}
 
@@ -171,6 +177,7 @@ func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
 				Description:  description,
 				DefaultValue: defaultValue,
 				TypeDefaults: defaults,
+				IsSensitive:  isSensitive,
 			}
 		case "output":
 			content, _, contentDiags := block.Body.PartialContent(outputSchema)

--- a/schema/stacks/deploy_schema_merge.go
+++ b/schema/stacks/deploy_schema_merge.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	tfschema "github.com/hashicorp/terraform-schema/schema"
+	"github.com/hashicorp/terraform-schema/stack"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type DeploySchemaMerger struct {
+	coreSchema *schema.BodySchema
+}
+
+func NewDeploySchemaMerger(coreSchema *schema.BodySchema) *DeploySchemaMerger {
+	return &DeploySchemaMerger{
+		coreSchema: coreSchema,
+	}
+}
+
+// SchemaForDeployment returns the schema for a deployment block
+func (m *DeploySchemaMerger) SchemaForDeployment(meta *stack.Meta) (*schema.BodySchema, error) {
+	if m.coreSchema == nil {
+		return nil, tfschema.CoreSchemaRequiredErr{}
+	}
+
+	mergedSchema := m.coreSchema.Copy()
+
+	constr, err := constraintForDeploymentInputs(*meta)
+	if err != nil {
+		return mergedSchema, err
+	}
+
+	// TODO: isOptional should be set to true if at least one input is required
+	mergedSchema.Blocks["deployment"].Body.Attributes["inputs"].Constraint = constr
+
+	return mergedSchema, nil
+}
+
+func constraintForDeploymentInputs(stackMeta stack.Meta) (schema.Constraint, error) {
+	inputs := make(map[string]*schema.AttributeSchema, 0)
+
+	for name, variable := range stackMeta.Variables {
+		varType := variable.Type
+		if varType == cty.NilType {
+			varType = cty.DynamicPseudoType
+		}
+		aSchema := StackVarToAttribute(variable)
+		aSchema.Constraint = tfschema.ConvertAttributeTypeToConstraint(varType)
+
+		inputs[name] = aSchema
+	}
+
+	return schema.Object{
+		Attributes: inputs,
+	}, nil
+}
+
+func StackVarToAttribute(stackVar stack.Variable) *schema.AttributeSchema {
+	aSchema := &schema.AttributeSchema{
+		IsSensitive: stackVar.IsSensitive,
+	}
+
+	if stackVar.Description != "" {
+		aSchema.Description = lang.PlainText(stackVar.Description)
+	}
+
+	if stackVar.DefaultValue == cty.NilVal {
+		aSchema.IsRequired = true
+	} else {
+		aSchema.IsOptional = true
+	}
+
+	return aSchema
+}

--- a/stack/variable.go
+++ b/stack/variable.go
@@ -12,6 +12,8 @@ type Variable struct {
 	Description string
 	Type        cty.Type
 
+	IsSensitive bool
+
 	// DefaultValue represents default value if one is defined
 	// and is decodable without errors, else cty.NilVal
 	DefaultValue cty.Value


### PR DESCRIPTION
Adds a schema merger for stack deployment files to add completion and hover support for `deployment` blocks in deployment configuration.

![completions](https://github.com/user-attachments/assets/98ab6281-3982-4ea3-9c41-ca5fd5b3e89d)
