### PR TITLE
Static schema support for Terraform Test and Mock files

### DIFF
--- a/earlydecoder/tests/decoder.go
+++ b/earlydecoder/tests/decoder.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	tftest "github.com/hashicorp/terraform-schema/test"
+)
+
+func LoadTest(path string, files map[string]*hcl.File) (*tftest.Meta, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	filenames := make([]string, 0)
+
+	mod := newDecodedTest()
+	for filename, f := range files {
+		filenames = append(filenames, filename)
+		fDiags := loadTestFromFile(f, mod)
+		diags = append(diags, fDiags...)
+	}
+
+	sort.Strings(filenames)
+
+	return &tftest.Meta{
+		Path:      path,
+		Filenames: filenames,
+	}, diags
+}

--- a/earlydecoder/tests/decoder_test.go
+++ b/earlydecoder/tests/decoder_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	tftest "github.com/hashicorp/terraform-schema/test"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+)
+
+type testCase struct {
+	name          string
+	cfg           string
+	expectedMeta  *tftest.Meta
+	expectedError hcl.Diagnostics
+}
+
+var customComparer = []cmp.Option{
+	cmp.Comparer(compareVersionConstraint),
+	ctydebug.CmpOptions,
+}
+
+func TestLoadTest(t *testing.T) {
+	path := t.TempDir()
+
+	testCases := []testCase{
+		{
+			"empty config",
+			``,
+			&tftest.Meta{
+				Path:      path,
+				Filenames: []string{"test.tftest.hcl"},
+			},
+			nil,
+		},
+		// TODO: add more test once we do more early decoding
+	}
+
+	runTestCases(testCases, t, path)
+}
+
+func runTestCases(testCases []testCase, t *testing.T, path string) {
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			f, diags := hclsyntax.ParseConfig([]byte(tc.cfg), "test.tftest.hcl", hcl.InitialPos)
+			if len(diags) > 0 {
+				t.Fatal(diags)
+			}
+			files := map[string]*hcl.File{
+				"test.tftest.hcl": f,
+			}
+
+			meta, diags := LoadTest(path, files)
+
+			if diff := cmp.Diff(tc.expectedError, diags, customComparer...); diff != "" {
+				t.Fatalf("expected errors doesn't match: %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedMeta, meta, customComparer...); diff != "" {
+				t.Fatalf("test meta doesn't match: %s", diff)
+			}
+		})
+	}
+}
+
+func compareVersionConstraint(x, y *version.Constraint) bool {
+	return x.Equals(y)
+}

--- a/earlydecoder/tests/load_tests.go
+++ b/earlydecoder/tests/load_tests.go
@@ -1,0 +1,35 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+// decodedTest is the type representing a decoded Terraform test.
+type decodedTest struct {
+}
+
+func newDecodedTest() *decodedTest {
+	return &decodedTest{}
+}
+
+// loadTestFromFile reads given file, interprets it and stores in given test
+// This is useful for any caller which does tokenization/parsing on its own
+// e.g. because it will reuse these parsed files later for more detailed
+// interpretation.
+func loadTestFromFile(file *hcl.File, _ *decodedTest) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	content, _, contentDiags := file.Body.PartialContent(rootSchema)
+	diags = append(diags, contentDiags...)
+	for _, block := range content.Blocks {
+		switch block.Type {
+		// TODO? decode mock_provider blocks (they have a source attribute)
+		// TODO? decode run -> module blocks (they have a source attribute)
+		}
+	}
+
+	return diags
+}

--- a/earlydecoder/tests/schema.go
+++ b/earlydecoder/tests/schema.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+var rootSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       "run",
+			LabelNames: []string{"name"},
+		},
+		{
+			Type: "variables",
+		},
+		{
+			Type:       "provider",
+			LabelNames: []string{"name"},
+		},
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/hashicorp/terraform-schema
 
-go 1.21.0
+go 1.22.0
+
 toolchain go1.22.5
 
 require (

--- a/internal/schema/tests/1.6/provider_block.go
+++ b/internal/schema/tests/1.6/provider_block.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func providerBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.LabelStep{Index: 0},
+				schema.AttrValueStep{Name: "alias", IsOptional: true},
+			},
+			FriendlyName: "provider",
+			ScopeId:      refscope.ProviderScope,
+			AsReference:  true,
+		},
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Provider},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name, lang.TokenModifierDependent},
+				Description:            lang.PlainText("Provider Name"),
+				IsDepKey:               true,
+				Completable:            true,
+			},
+		},
+		Description: lang.PlainText("A provider block is used to specify a provider configuration"),
+		Body: &schema.BodySchema{
+			Extensions: &schema.BodyExtensions{
+				DynamicBlocks: true,
+			},
+			Attributes: map[string]*schema.AttributeSchema{
+				"alias": {
+					Constraint:  schema.LiteralType{Type: cty.String},
+					IsOptional:  true,
+					Description: lang.Markdown("Alias for using the same provider with different configurations for different resources, e.g. `eu-west`"),
+				},
+				"version": {
+					Constraint:   schema.LiteralType{Type: cty.String},
+					IsOptional:   true,
+					IsDeprecated: true,
+					Description: lang.Markdown("Specifies a version constraint for the provider. e.g. `~> 1.0`.\n" +
+						"**DEPRECATED:** Use `required_providers` block to manage provider version instead."),
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.6/root.go
+++ b/internal/schema/tests/1.6/root.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+)
+
+// TestSchema returns the static schema for a test
+// configuration (*.tftest.hcl) file.
+func TestSchema(_ *version.Version) *schema.BodySchema {
+	return &schema.BodySchema{
+		Blocks: map[string]*schema.BlockSchema{
+			"run":       runBlockSchema(),
+			"provider":  providerBlockSchema(),
+			"variables": variablesBlockSchema(),
+		},
+	}
+}

--- a/internal/schema/tests/1.6/run_block.go
+++ b/internal/schema/tests/1.6/run_block.go
@@ -1,0 +1,147 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func runBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Run},
+		Description:            lang.PlainText("A run block represents a single Terraform command to be executed and a set of validations to run after the command."),
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Run Name"),
+			},
+		},
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"command": {
+					Constraint: schema.OneOf{
+						schema.Keyword{
+							Keyword:     "apply",
+							Description: lang.Markdown("The operation is an apply operation."),
+						},
+						schema.Keyword{
+							Keyword:     "plan",
+							Description: lang.Markdown("The operation is a plan operation."),
+						},
+					},
+					Description: lang.Markdown(""), // TODO!
+					IsOptional:  true,
+				},
+				"providers": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{},
+					},
+					Description: lang.Markdown(""), // TODO!
+					IsOptional:  true,
+				},
+				"expect_failures": {
+					Constraint: schema.List{
+						Elem: schema.OneOf{
+							// TODO? check blocks
+							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.DataScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
+							schema.Reference{OfScopeId: refscope.OutputScope},
+						},
+					},
+					Description: lang.Markdown(""), // TODO!
+					IsOptional:  true,
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"plan_options": { // TODO!
+					Description: lang.Markdown(""),
+					Body: &schema.BodySchema{
+						Attributes: map[string]*schema.AttributeSchema{
+							"mode": {
+								Constraint: schema.OneOf{
+									schema.Keyword{
+										Keyword:     "normal",
+										Description: lang.Markdown(""), // TODO!
+									},
+									schema.Keyword{
+										Keyword:     "refresh-only",
+										Description: lang.Markdown(""), // TODO!
+									},
+								},
+								Description: lang.Markdown(""), // TODO!
+								IsOptional:  true,
+							},
+							"refresh": {
+								Constraint:   schema.LiteralType{Type: cty.Bool},
+								Description:  lang.Markdown(""), // TODO!
+								DefaultValue: schema.DefaultValue{Value: cty.BoolVal(true)},
+								IsOptional:   true,
+							},
+							"replace": {
+								Constraint: schema.List{
+									Elem: schema.Reference{OfScopeId: refscope.ResourceScope},
+								},
+								Description: lang.Markdown(""), // TODO!
+								IsOptional:  true,
+							},
+							"target": {
+								Constraint: schema.List{
+									Elem: schema.Reference{OfScopeId: refscope.ResourceScope},
+								},
+								Description: lang.Markdown(""), // TODO!
+								IsOptional:  true,
+							},
+						},
+					},
+				},
+				"assert": {
+					Description: lang.Markdown(""), // TODO!
+					Body: &schema.BodySchema{
+						Attributes: map[string]*schema.AttributeSchema{
+							"condition": {
+								Constraint:  schema.AnyExpression{OfType: cty.Bool},
+								IsRequired:  true,
+								Description: lang.Markdown("Condition to meet for the check to pass (any expression which evaluates to boolean)"),
+							},
+							"error_message": {
+								Constraint:  schema.AnyExpression{OfType: cty.String},
+								IsRequired:  true,
+								Description: lang.Markdown("Text that Terraform will include as part of error messages when it detects an unmet condition"),
+							},
+						},
+					},
+				},
+				"variables": variablesBlockSchema(),
+				"module": {
+					Description: lang.Markdown(""), // TODO!
+					Body: &schema.BodySchema{
+						Attributes: map[string]*schema.AttributeSchema{
+							"source": {
+								Constraint: schema.LiteralType{Type: cty.String},
+								Description: lang.Markdown("Source where to load the module from, " +
+									"a local directory (e.g. `./module`) or a remote address - e.g. " +
+									"`hashicorp/consul/aws` (Terraform Registry address)"),
+								IsRequired:             true,
+								IsDepKey:               true,
+								SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+							},
+							"version": {
+								Constraint: schema.LiteralType{Type: cty.String},
+								IsOptional: true,
+								Description: lang.Markdown("Constraint to set the version of the module, e.g. `~> 1.0`." +
+									" Only applicable to modules in a module registry."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.6/run_block.go
+++ b/internal/schema/tests/1.6/run_block.go
@@ -35,14 +35,14 @@ func runBlockSchema() *schema.BlockSchema {
 							Description: lang.Markdown("The operation is a plan operation."),
 						},
 					},
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("The Terraform command to be run in this test. By default, each run block executes with `command = apply` instructing Terraform to execute a complete apply operation against your configuration. Replacing the command value with `command = plan` instructs Terraform to _not_ create new infrastructure for this run block. This allows test authors to validate logical operations and custom conditions within their infrastructure in a process analogous to unit testing."),
 					IsOptional:  true,
 				},
 				"providers": {
 					Constraint: schema.Object{
 						Attributes: schema.ObjectAttributes{},
 					},
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Explicit mapping of providers to use for this run block. If not set, each provider you specify is directly available within each run block."),
 					IsOptional:  true,
 				},
 				"expect_failures": {
@@ -55,32 +55,32 @@ func runBlockSchema() *schema.BlockSchema {
 							schema.Reference{OfScopeId: refscope.OutputScope},
 						},
 					},
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Takes a list of checkable objects (resources, data sources, check blocks, input variables, and outputs) that should fail their custom conditions. The test passes if the checkable objects you specify report an issue, and the test fails overall if they do not. Read more on [expect_failures](https://developer.hashicorp.com/terraform/language/tests#expecting-failures)"),
 					IsOptional:  true,
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{
-				"plan_options": { // TODO!
-					Description: lang.Markdown(""),
+				"plan_options": {
+					Description: lang.Markdown("Allows to customize the planning mode and options typically needed to edit via command-line flags and options."),
 					Body: &schema.BodySchema{
 						Attributes: map[string]*schema.AttributeSchema{
 							"mode": {
 								Constraint: schema.OneOf{
 									schema.Keyword{
 										Keyword:     "normal",
-										Description: lang.Markdown(""), // TODO!
+										Description: lang.Markdown("Default planning mode which will run an implicit in-memory refresh as part of the plan"),
 									},
 									schema.Keyword{
 										Keyword:     "refresh-only",
-										Description: lang.Markdown(""), // TODO!
+										Description: lang.Markdown("Allows to safely refresh Terraform state without making any modifications to your infrastructure"),
 									},
 								},
-								Description: lang.Markdown(""), // TODO!
+								Description: lang.Markdown("Whether to run Terraform normal or in refresh-only mode"),
 								IsOptional:  true,
 							},
 							"refresh": {
 								Constraint:   schema.LiteralType{Type: cty.Bool},
-								Description:  lang.Markdown(""), // TODO!
+								Description:  lang.Markdown("When set to false, it disables the default behavior of synchronizing the Terraform state with remote objects before checking for configuration changes."),
 								DefaultValue: schema.DefaultValue{Value: cty.BoolVal(true)},
 								IsOptional:   true,
 							},
@@ -88,21 +88,21 @@ func runBlockSchema() *schema.BlockSchema {
 								Constraint: schema.List{
 									Elem: schema.Reference{OfScopeId: refscope.ResourceScope},
 								},
-								Description: lang.Markdown(""), // TODO!
+								Description: lang.Markdown("Instructs Terraform to plan to replace the resource instance with the given address."),
 								IsOptional:  true,
 							},
 							"target": {
 								Constraint: schema.List{
 									Elem: schema.Reference{OfScopeId: refscope.ResourceScope},
 								},
-								Description: lang.Markdown(""), // TODO!
+								Description: lang.Markdown("Instructs Terraform to focus its planning efforts only on resource instances which match the given address and on any objects that those instances depend on."),
 								IsOptional:  true,
 							},
 						},
 					},
 				},
 				"assert": {
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("At the conclusion of a Terraform test command execution, Terraform presents any failed assertions as part of a tests passed or failed status."),
 					Body: &schema.BodySchema{
 						Attributes: map[string]*schema.AttributeSchema{
 							"condition": {
@@ -120,7 +120,7 @@ func runBlockSchema() *schema.BlockSchema {
 				},
 				"variables": variablesBlockSchema(),
 				"module": {
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Used to modify the module that a given run block executes"),
 					Body: &schema.BodySchema{
 						Attributes: map[string]*schema.AttributeSchema{
 							"source": {

--- a/internal/schema/tests/1.6/variables_block.go
+++ b/internal/schema/tests/1.6/variables_block.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func variablesBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		MaxItems:               1,
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variables},
+		Description:            lang.Markdown(""), // TODO!
+		Body: &schema.BodySchema{
+			AnyAttribute: &schema.AttributeSchema{
+				Address: &schema.AttributeAddrSchema{
+					Steps: []schema.AddrStep{
+						schema.StaticStep{Name: "var"},
+						schema.AttrNameStep{},
+					},
+					ScopeId:     refscope.VariableScope,
+					AsExprType:  true,
+					AsReference: true,
+				},
+				Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.6/variables_block.go
+++ b/internal/schema/tests/1.6/variables_block.go
@@ -15,7 +15,7 @@ func variablesBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
 		MaxItems:               1,
 		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variables},
-		Description:            lang.Markdown(""), // TODO!
+		Description:            lang.Markdown("Provides values for input variables within your configuration directly from your test files"),
 		Body: &schema.BodySchema{
 			AnyAttribute: &schema.AttributeSchema{
 				Address: &schema.AttributeAddrSchema{

--- a/internal/schema/tests/1.7/mock_data_block.go
+++ b/internal/schema/tests/1.7/mock_data_block.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+)
+
+func mockDataBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "type",
+				Description:            lang.PlainText("Data Source Type"),
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Type, lang.TokenModifierDependent},
+				IsDepKey:               true,
+				Completable:            true,
+			},
+		},
+		Description: lang.PlainText(""), // TODO!
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"defaults": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.7/mock_data_block.go
+++ b/internal/schema/tests/1.7/mock_data_block.go
@@ -20,7 +20,7 @@ func mockDataBlockSchema() *schema.BlockSchema {
 				Completable:            true,
 			},
 		},
-		Description: lang.PlainText(""), // TODO!
+		Description: lang.PlainText("Allows to specify specific values for targeted data sources"),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"defaults": {
@@ -28,7 +28,7 @@ func mockDataBlockSchema() *schema.BlockSchema {
 						Attributes: schema.ObjectAttributes{},
 					},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Specify the values that should be returned for specific attributes"),
 				},
 			},
 		},

--- a/internal/schema/tests/1.7/mock_provider_block.go
+++ b/internal/schema/tests/1.7/mock_provider_block.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func mockProviderBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Provider},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name, lang.TokenModifierDependent},
+				Description:            lang.PlainText("Provider Name"),
+				IsDepKey:               true,
+				Completable:            true,
+			},
+		},
+		Description: lang.PlainText(""), // TODO!
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"alias": {
+					Constraint:  schema.LiteralType{Type: cty.String},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+				"source": {
+					Constraint:  schema.LiteralType{Type: cty.String},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"mock_resource":     mockResourceBlockSchema(),
+				"mock_data":         mockDataBlockSchema(),
+				"override_resource": overrideResourceBlockSchema(),
+				"override_data":     overrideDataBlockSchema(),
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.7/mock_provider_block.go
+++ b/internal/schema/tests/1.7/mock_provider_block.go
@@ -22,18 +22,18 @@ func mockProviderBlockSchema() *schema.BlockSchema {
 				Completable:            true,
 			},
 		},
-		Description: lang.PlainText(""), // TODO!
+		Description: lang.PlainText("In Terraform tests, you can mock a provider with the mock_provider block. Mock providers return the same schema as the original provider and you can pass the mocked provider to your tests in place of the matching provider. All resources and data sources retrieved by a mock provider will set the relevant values from the configuration, and generate fake data for any computed attributes."),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"alias": {
 					Constraint:  schema.LiteralType{Type: cty.String},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Alias for using the same provider with different configurations for different resources, e.g. `mock`"),
 				},
 				"source": {
 					Constraint:  schema.LiteralType{Type: cty.String},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Path to a directory that includes dedicated mock data files (*.tfmock.hcl). These can be used to share mock provider data between tests. You can combine the source attribute with directly nested mock_resource and mock_data blocks. If the source location and a directly nested block describe the same resource or data source then the directly nested block takes precedence."),
 				},
 			},
 			Blocks: map[string]*schema.BlockSchema{

--- a/internal/schema/tests/1.7/mock_resource_block.go
+++ b/internal/schema/tests/1.7/mock_resource_block.go
@@ -20,7 +20,7 @@ func mockResourceBlockSchema() *schema.BlockSchema {
 				Completable:            true,
 			},
 		},
-		Description: lang.PlainText(""), // TODO!
+		Description: lang.PlainText("Allows to specify specific values for targeted resources"),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"defaults": {
@@ -28,7 +28,7 @@ func mockResourceBlockSchema() *schema.BlockSchema {
 						Attributes: schema.ObjectAttributes{},
 					},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Specify the values that should be returned for specific attributes"),
 				},
 			},
 		},

--- a/internal/schema/tests/1.7/mock_resource_block.go
+++ b/internal/schema/tests/1.7/mock_resource_block.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+)
+
+func mockResourceBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "type",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Type, lang.TokenModifierDependent},
+				Description:            lang.PlainText("Resource Type"),
+				IsDepKey:               true,
+				Completable:            true,
+			},
+		},
+		Description: lang.PlainText(""), // TODO!
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"defaults": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.7/override_data_block.go
+++ b/internal/schema/tests/1.7/override_data_block.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+)
+
+func overrideDataBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.PlainText(""), // TODO!
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"target": {
+					Constraint: schema.Reference{
+						OfScopeId: refscope.DataScope,
+					},
+					IsRequired:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+				"values": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.7/override_data_block.go
+++ b/internal/schema/tests/1.7/override_data_block.go
@@ -11,7 +11,7 @@ import (
 
 func overrideDataBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
-		Description: lang.PlainText(""), // TODO!
+		Description: lang.PlainText("Allows overriding the values of a specific data source in the targeted configuration"),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"target": {
@@ -19,14 +19,14 @@ func overrideDataBlockSchema() *schema.BlockSchema {
 						OfScopeId: refscope.DataScope,
 					},
 					IsRequired:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Reference to the data source to override"),
 				},
 				"values": {
 					Constraint: schema.Object{
 						Attributes: schema.ObjectAttributes{},
 					},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Specify the values that should be returned for specific attributes"),
 				},
 			},
 		},

--- a/internal/schema/tests/1.7/override_module_block.go
+++ b/internal/schema/tests/1.7/override_module_block.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+)
+
+func overrideModuleBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.PlainText(""), // TODO!
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"target": {
+					Constraint: schema.Reference{
+						OfScopeId: refscope.ModuleScope,
+					},
+					IsRequired:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+				"outputs": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.7/override_module_block.go
+++ b/internal/schema/tests/1.7/override_module_block.go
@@ -11,7 +11,7 @@ import (
 
 func overrideModuleBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
-		Description: lang.PlainText(""), // TODO!
+		Description: lang.PlainText("Allows overriding the outputs of a specific module in the targeted configuration"),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"target": {
@@ -19,14 +19,14 @@ func overrideModuleBlockSchema() *schema.BlockSchema {
 						OfScopeId: refscope.ModuleScope,
 					},
 					IsRequired:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Reference to the module to override"),
 				},
 				"outputs": {
 					Constraint: schema.Object{
 						Attributes: schema.ObjectAttributes{},
 					},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Specify the values that should be returned for specific attributes"),
 				},
 			},
 		},

--- a/internal/schema/tests/1.7/override_resource_block.go
+++ b/internal/schema/tests/1.7/override_resource_block.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+)
+
+func overrideResourceBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.PlainText(""), // TODO!
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"target": {
+					Constraint: schema.Reference{
+						OfScopeId: refscope.ResourceScope,
+					},
+					IsRequired:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+				"values": {
+					Constraint: schema.Object{
+						Attributes: schema.ObjectAttributes{},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown(""), // TODO!
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/tests/1.7/override_resource_block.go
+++ b/internal/schema/tests/1.7/override_resource_block.go
@@ -11,7 +11,7 @@ import (
 
 func overrideResourceBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
-		Description: lang.PlainText(""), // TODO!
+		Description: lang.PlainText("Allows overriding the values of a specific resource in the targeted configuration"),
 		Body: &schema.BodySchema{
 			Attributes: map[string]*schema.AttributeSchema{
 				"target": {
@@ -19,14 +19,14 @@ func overrideResourceBlockSchema() *schema.BlockSchema {
 						OfScopeId: refscope.ResourceScope,
 					},
 					IsRequired:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Reference to the resource to override"),
 				},
 				"values": {
 					Constraint: schema.Object{
 						Attributes: schema.ObjectAttributes{},
 					},
 					IsOptional:  true,
-					Description: lang.Markdown(""), // TODO!
+					Description: lang.Markdown("Specify the values that should be returned for specific attributes"),
 				},
 			},
 		},

--- a/internal/schema/tests/1.7/root.go
+++ b/internal/schema/tests/1.7/root.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+
+	v1_6_test "github.com/hashicorp/terraform-schema/internal/schema/tests/1.6"
+)
+
+// TestSchema returns the static schema for a test
+// configuration (*.tftest.hcl) file.
+func TestSchema(v *version.Version) *schema.BodySchema {
+	bs := v1_6_test.TestSchema(v)
+
+	bs.Blocks["mock_provider"] = mockProviderBlockSchema()
+	bs.Blocks["override_resource"] = overrideResourceBlockSchema()
+	bs.Blocks["override_data"] = overrideDataBlockSchema()
+	bs.Blocks["override_module"] = overrideModuleBlockSchema()
+
+	bs.Blocks["run"].Body.Blocks["override_resource"] = overrideResourceBlockSchema()
+	bs.Blocks["run"].Body.Blocks["override_data"] = overrideDataBlockSchema()
+	bs.Blocks["run"].Body.Blocks["override_module"] = overrideModuleBlockSchema()
+
+	return bs
+}
+
+// MockSchema returns the static schema for a mock
+// configuration (*.tfmock.hcl) file.
+func MockSchema(_ *version.Version) *schema.BodySchema {
+	return &schema.BodySchema{
+		Blocks: map[string]*schema.BlockSchema{
+			"mock_resource":     mockResourceBlockSchema(),
+			"mock_data":         mockDataBlockSchema(),
+			"override_resource": overrideResourceBlockSchema(),
+			"override_data":     overrideDataBlockSchema(),
+		},
+	}
+}

--- a/internal/schema/tests/1.9/root.go
+++ b/internal/schema/tests/1.9/root.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+
+	v1_7_test "github.com/hashicorp/terraform-schema/internal/schema/tests/1.7"
+)
+
+// TestSchema returns the static schema for a test
+// configuration (*.tftest.hcl) file.
+func TestSchema(v *version.Version) *schema.BodySchema {
+	bs := v1_7_test.TestSchema(v)
+
+	// Removes the version attribute
+	bs.Blocks["provider"].Body.Attributes = map[string]*schema.AttributeSchema{
+		"alias": {
+			Constraint:  schema.LiteralType{Type: cty.String},
+			IsOptional:  true,
+			Description: lang.Markdown("Alias for using the same provider with different configurations for different resources, e.g. `eu-west`"),
+		},
+	}
+
+	return bs
+}

--- a/internal/schema/tokmod/token_modifier.go
+++ b/internal/schema/tokmod/token_modifier.go
@@ -22,6 +22,8 @@ var (
 	Name              = lang.SemanticTokenModifier("terraform-name")
 	Type              = lang.SemanticTokenModifier("terraform-type")
 	RequiredProviders = lang.SemanticTokenModifier("terraform-requiredProviders")
+	Run               = lang.SemanticTokenModifier("terraform-run")
+	Variables         = lang.SemanticTokenModifier("terraform-variables")
 )
 
 var SupportedModifiers = []lang.SemanticTokenModifier{
@@ -36,7 +38,9 @@ var SupportedModifiers = []lang.SemanticTokenModifier{
 	Provisioner,
 	RequiredProviders,
 	Resource,
+	Run,
 	Terraform,
 	Type,
 	Variable,
+	Variables,
 }

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -9,9 +9,9 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-type coreSchemaRequiredErr struct{}
+type CoreSchemaRequiredErr struct{}
 
-func (e coreSchemaRequiredErr) Error() string {
+func (e CoreSchemaRequiredErr) Error() string {
 	return "core schema required (none provided)"
 }
 

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -62,7 +62,7 @@ func (m *SchemaMerger) SetTerraformVersion(v *version.Version) {
 
 func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, error) {
 	if m.coreSchema == nil {
-		return nil, coreSchemaRequiredErr{}
+		return nil, CoreSchemaRequiredErr{}
 	}
 
 	if meta == nil {

--- a/schema/schema_merge_test.go
+++ b/schema/schema_merge_test.go
@@ -44,7 +44,7 @@ func TestSchemaMerger_SchemaForModule_noCoreSchema(t *testing.T) {
 		t.Fatal("expected error for nil core schema")
 	}
 
-	if !errors.Is(err, coreSchemaRequiredErr{}) {
+	if !errors.Is(err, CoreSchemaRequiredErr{}) {
 		t.Fatalf("unexpected error: %#v", err)
 	}
 }

--- a/schema/tests/mock_schema.go
+++ b/schema/tests/mock_schema.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+	test_v1_7 "github.com/hashicorp/terraform-schema/internal/schema/tests/1.7"
+	tfschema "github.com/hashicorp/terraform-schema/schema"
+)
+
+// CoreMockSchemaForVersion finds a schema for mock configuration files
+// that is relevant for the given Terraform version.
+// It will return an error if such schema cannot be found.
+func CoreMockSchemaForVersion(v *version.Version) (*schema.BodySchema, error) {
+	ver := v.Core()
+
+	if ver.GreaterThanOrEqual(v1_7) {
+		return test_v1_7.MockSchema(ver), nil
+	}
+
+	return nil, tfschema.NoCompatibleSchemaErr{Version: ver}
+}

--- a/schema/tests/mock_schema_merge.go
+++ b/schema/tests/mock_schema_merge.go
@@ -39,8 +39,8 @@ func (m *MockSchemaMerger) SchemaForMock(meta *tftest.Meta) (*schema.BodySchema,
 
 	mergedSchema := m.coreSchema.Copy()
 
-	// TODO merge mock_resource blocks - use the label as dependency key
-	// TODO merge mock_data blocks - use the label as dependency key
+	// TODO merge mock_resource blocks - use the label as dependency key TFECO-7471
+	// TODO merge mock_data blocks - use the label as dependency key TFECO-7472
 
 	return mergedSchema, nil
 }

--- a/schema/tests/mock_schema_merge.go
+++ b/schema/tests/mock_schema_merge.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/schema"
+	tfschema "github.com/hashicorp/terraform-schema/schema"
+	tftest "github.com/hashicorp/terraform-schema/test"
+)
+
+type MockSchemaMerger struct {
+	coreSchema  *schema.BodySchema
+	stateReader StateReader
+}
+
+func NewMockSchemaMerger(coreSchema *schema.BodySchema) *MockSchemaMerger {
+	return &MockSchemaMerger{
+		coreSchema: coreSchema,
+	}
+}
+
+func (m *MockSchemaMerger) SetStateReader(mr StateReader) {
+	m.stateReader = mr
+}
+
+func (m *MockSchemaMerger) SchemaForMock(meta *tftest.Meta) (*schema.BodySchema, error) {
+	if m.coreSchema == nil {
+		return nil, tfschema.CoreSchemaRequiredErr{}
+	}
+
+	if meta == nil {
+		return m.coreSchema, nil
+	}
+
+	if m.stateReader == nil {
+		return m.coreSchema, nil
+	}
+
+	mergedSchema := m.coreSchema.Copy()
+
+	// TODO merge mock_resource blocks - use the label as dependency key
+	// TODO merge mock_data blocks - use the label as dependency key
+
+	return mergedSchema, nil
+}

--- a/schema/tests/test_schema.go
+++ b/schema/tests/test_schema.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+	test_v1_6 "github.com/hashicorp/terraform-schema/internal/schema/tests/1.6"
+	test_v1_7 "github.com/hashicorp/terraform-schema/internal/schema/tests/1.7"
+	test_v1_9 "github.com/hashicorp/terraform-schema/internal/schema/tests/1.9"
+	tfschema "github.com/hashicorp/terraform-schema/schema"
+)
+
+var (
+	v1_6 = version.Must(version.NewVersion("1.6"))
+	v1_7 = version.Must(version.NewVersion("1.7"))
+	v1_9 = version.Must(version.NewVersion("1.9"))
+)
+
+// CoreTestSchemaForVersion finds a schema for test configuration files
+// that is relevant for the given Terraform version.
+// It will return an error if such schema cannot be found.
+func CoreTestSchemaForVersion(v *version.Version) (*schema.BodySchema, error) {
+	ver := v.Core()
+
+	if ver.GreaterThanOrEqual(v1_9) {
+		return test_v1_9.TestSchema(ver), nil
+	}
+	if ver.GreaterThanOrEqual(v1_7) {
+		return test_v1_7.TestSchema(ver), nil
+	}
+	if ver.GreaterThanOrEqual(v1_6) {
+		return test_v1_6.TestSchema(ver), nil
+	}
+
+	return nil, tfschema.NoCompatibleSchemaErr{Version: ver}
+}

--- a/schema/tests/test_schema_merge.go
+++ b/schema/tests/test_schema_merge.go
@@ -53,11 +53,12 @@ func (m *TestSchemaMerger) SchemaForTest(meta *tftest.Meta) (*schema.BodySchema,
 
 	mergedSchema := m.coreSchema.Copy()
 
-	// TODO merge mock_provider blocks - use the label as dependency key AND the source if defined
-	// TODO merge nested mock_resource blocks - use the label as dependency key
-	// TODO merge nested mock_data blocks - use the label as dependency key
-	// TODO merge run - module blocks - use the source as dependency key
-	// TODO merge variables - source them from the Terraform module meta
+	// TODO merge mock_provider blocks - use the label as dependency key AND the source if defined TFECO-7476
+	// TODO merge nested mock_resource blocks - use the label as dependency key TFECO-7474
+	// TODO merge nested mock_data blocks - use the label as dependency key TFECO-7475
+	// TODO merge run - module blocks - use the source as dependency key TFECO-7477
+	// TODO merge variables - source them from the Terraform module meta TFECO-7478
+	// TODO merge provider - source them from the Terraform module meta requirements TFECO-7522
 
 	return mergedSchema, nil
 }

--- a/schema/tests/test_schema_merge.go
+++ b/schema/tests/test_schema_merge.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+	tfmod "github.com/hashicorp/terraform-schema/module"
+	tfschema "github.com/hashicorp/terraform-schema/schema"
+	tftest "github.com/hashicorp/terraform-schema/test"
+)
+
+type TestSchemaMerger struct {
+	coreSchema  *schema.BodySchema
+	stateReader StateReader
+}
+
+// StateReader exposes a set of methods to read data from the internal language server state
+type StateReader interface {
+	// ProviderSchema returns the schema for a provider we have stored in memory. The can come
+	// from different sources.
+	ProviderSchema(modPath string, addr tfaddr.Provider, vc version.Constraints) (*tfschema.ProviderSchema, error)
+
+	// LocalModuleMeta returns the module meta data for a local module. This is the result
+	// of the [earlydecoder] when processing module files
+	LocalModuleMeta(modPath string) (*tfmod.Meta, error)
+}
+
+func NewTestSchemaMerger(coreSchema *schema.BodySchema) *TestSchemaMerger {
+	return &TestSchemaMerger{
+		coreSchema: coreSchema,
+	}
+}
+
+func (m *TestSchemaMerger) SetStateReader(mr StateReader) {
+	m.stateReader = mr
+}
+
+func (m *TestSchemaMerger) SchemaForTest(meta *tftest.Meta) (*schema.BodySchema, error) {
+	if m.coreSchema == nil {
+		return nil, tfschema.CoreSchemaRequiredErr{}
+	}
+
+	if meta == nil {
+		return m.coreSchema, nil
+	}
+
+	if m.stateReader == nil {
+		return m.coreSchema, nil
+	}
+
+	mergedSchema := m.coreSchema.Copy()
+
+	// TODO merge mock_provider blocks - use the label as dependency key AND the source if defined
+	// TODO merge nested mock_resource blocks - use the label as dependency key
+	// TODO merge nested mock_data blocks - use the label as dependency key
+	// TODO merge run - module blocks - use the source as dependency key
+	// TODO merge variables - source them from the Terraform module meta
+
+	return mergedSchema, nil
+}

--- a/test/meta.go
+++ b/test/meta.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stack
+
+type Meta struct {
+	Path      string
+	Filenames []string
+}


### PR DESCRIPTION
This PR adds static schema support for Terraform Test and Mock files. This includes completions for Test specific block types, descriptions on hover for these blocks and the same for Mock files.