### PR TITLE
Add input block schema and deprecate variable block

### DIFF
--- a/internal/schema/stacks/1.10/input_block.go
+++ b/internal/schema/stacks/1.10/input_block.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func inputBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variable},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Input Name"),
+			},
+		},
+		Description: lang.Markdown("Stack inputs allow users to customize aspects of the stack that differ between deployments" +
+			"(e.g. different instance sizes, regions, etc.)"),
+		Body: &schema.BodySchema{
+			Attributes: map[string]*schema.AttributeSchema{
+				"description": {
+					Constraint:  schema.LiteralType{Type: cty.String},
+					IsOptional:  true,
+					Description: lang.Markdown("Description to document the purpose of the input and what value is expected"),
+				},
+				"type": {
+					Constraint:  schema.TypeDeclaration{},
+					IsOptional:  true,
+					Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
+				},
+				"default": {
+					Constraint:  schema.TypeDeclaration{},
+					IsOptional:  true,
+					Description: lang.Markdown("A literal expression of an appropriate type for the input"),
+				},
+			},
+		},
+	}
+}

--- a/internal/schema/stacks/1.10/root.go
+++ b/internal/schema/stacks/1.10/root.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	v1_9_mod "github.com/hashicorp/terraform-schema/internal/schema/stacks/1.9"
+)
+
+// StackSchema returns the static schema for a stack
+// configuration (*.tfstack.hcl) file.
+func StackSchema(_ *version.Version) *schema.BodySchema {
+	bs := v1_9_mod.StackSchema(nil)
+
+	bs.Blocks["variable"].IsDeprecated = true
+	bs.Blocks["variable"].Description = lang.Markdown("The `variables` attribute has been replaced with the `inputs` attribute. Please update the configuration to use `inputs` instead of `variables`, as support for the `variables` attribute will be removed entirely before the final release of Terraform Stacks.")
+
+	bs.Blocks["input"] = inputBlockSchema()
+
+	return bs
+}
+
+// DeploymentSchema returns the static schema for a deployment
+// configuration (*.tfdeploy.hcl) file.
+func DeploymentSchema(_ *version.Version) *schema.BodySchema {
+	bs := v1_9_mod.DeploymentSchema(nil)
+
+	return bs
+}

--- a/schema/stacks/stack_schema.go
+++ b/schema/stacks/stack_schema.go
@@ -6,12 +6,12 @@ package schema
 import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl-lang/schema"
-	stack_1_9 "github.com/hashicorp/terraform-schema/internal/schema/stacks/1.9"
+	stack_1_10 "github.com/hashicorp/terraform-schema/internal/schema/stacks/1.10"
 )
 
 // CoreStackSchemaForVersion finds a schema for stack configuration files
 // that is relevant for the given Terraform version.
 // It will return an error if such schema cannot be found.
 func CoreStackSchemaForVersion(v *version.Version) (*schema.BodySchema, error) {
-	return stack_1_9.StackSchema(v), nil
+	return stack_1_10.StackSchema(v), nil
 }


### PR DESCRIPTION
This commit adds the schema for the `input` block in a stack configuration file and deprecates the `variable` block.

The `variable` block has been replaced with the `input` block. The `input` block allows users to customize aspects of the stack that differ between deployments.
