### PR TITLE
(TF-18959) deployments store block schema

### DIFF
--- a/internal/schema/stacks/1.9/root.go
+++ b/internal/schema/stacks/1.9/root.go
@@ -30,6 +30,7 @@ func DeploymentSchema(_ *version.Version) *schema.BodySchema {
 			"deployment":     deploymentBlockSchema(),
 			"identity_token": identityTokenBlockSchema(),
 			"orchestrate":    orchestrateBlockSchema(),
+			"store":          storeBlockSchema(),
 		},
 	}
 }

--- a/internal/schema/stacks/1.9/store_block.go
+++ b/internal/schema/stacks/1.9/store_block.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func storeBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.PlainText("A store block allows to retrieve credentials at plan and apply time. These credentials can be used as inputs to deployment blocks."),
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "type",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Type, lang.TokenModifierDependent},
+				Description:            lang.PlainText("Store type"),
+				IsDepKey:               true,
+				Completable:            true,
+			},
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Store name"),
+			},
+		},
+		DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Labels: []schema.LabelDependent{
+					{Index: 0, Value: "tfvars"},
+				},
+			}): {
+				Attributes: map[string]*schema.AttributeSchema{
+					"path": {
+						IsRequired:  true,
+						Constraint:  schema.LiteralType{Type: cty.String},
+						Description: lang.Markdown("The path to the tfvars file."),
+					},
+				},
+			},
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Labels: []schema.LabelDependent{
+					{Index: 0, Value: "varset"},
+				},
+			}): {
+				Attributes: map[string]*schema.AttributeSchema{
+					"id": {
+						IsRequired:  true,
+						Constraint:  schema.LiteralType{Type: cty.String},
+						Description: lang.Markdown("The id of the varset. In the form of 'varset-nnnnnnnnnnnnnnnn'."),
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds static schema support for the two existing `store` types
<img width="307" alt="image" src="https://github.com/user-attachments/assets/edb1ff70-d71f-4e8b-ae74-7ba8c805ae75">
<img width="463" alt="image" src="https://github.com/user-attachments/assets/62ee8f2a-da4b-44ae-a3d9-e4359073e070">
<img width="245" alt="image" src="https://github.com/user-attachments/assets/32a15717-8b1f-478c-b625-7cb9ec7ec872">
<img width="314" alt="image" src="https://github.com/user-attachments/assets/79bb506e-c647-40f8-93f9-af408b990d96">
