### PR TITLE
(TF-18666) feat: add Address to variable block schema for stacks to enable references

### DIFF
--- a/internal/schema/stacks/1.9/variable_block.go
+++ b/internal/schema/stacks/1.9/variable_block.go
@@ -6,12 +6,25 @@ package schema
 import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
 
 func variableBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "var"},
+				schema.LabelStep{Index: 0},
+			},
+			FriendlyName: "variable",
+			ScopeId:      refscope.VariableScope,
+			AsReference:  true,
+			AsTypeOf: &schema.BlockAsTypeOf{
+				AttributeExpr: "type",
+			},
+		},
 		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Variable},
 		Labels: []*schema.LabelSchema{
 			{


### PR DESCRIPTION
This enables completion of variable references, Hover & Go to definition on variables, and Go to references on variable blocks (not pictured in GIF)

![vars](https://github.com/user-attachments/assets/7e094a15-d960-4946-86a3-c3b4b97ec5de)
