### PR TITLE
(TF-18669) Enable component references

### DIFF
--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -28,8 +28,8 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagno
 	sort.Strings(filenames)
 
 	components := make(map[string]stack.Component)
-	for key, variable := range mod.Components {
-		components[key] = *variable
+	for key, component := range mod.Components {
+		components[key] = *component
 	}
 
 	variables := make(map[string]stack.Variable)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hc-install v0.7.0
-	github.com/hashicorp/hcl-lang v0.0.0-20240722075100-0f6cd5960306
+	github.com/hashicorp/hcl-lang v0.0.0-20240814155600-0ec9d4da3a96
 	github.com/hashicorp/hcl/v2 v2.21.0
 	github.com/hashicorp/terraform-exec v0.21.0
 	github.com/hashicorp/terraform-json v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC1659aBk=
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
-github.com/hashicorp/hcl-lang v0.0.0-20240722075100-0f6cd5960306 h1:VQ2epS4r2HtNzKJhJVR8sIHdsMV7L80lCvwJkX02hd0=
-github.com/hashicorp/hcl-lang v0.0.0-20240722075100-0f6cd5960306/go.mod h1:4uIIEYVWTw+fDs9LVKy1CPnL6Z0XcLOjmanj7fVCIpE=
+github.com/hashicorp/hcl-lang v0.0.0-20240814155600-0ec9d4da3a96 h1:WVwJNemS0Him2WhrRUrc6fO/e49w238IcyKXDYoo71w=
+github.com/hashicorp/hcl-lang v0.0.0-20240814155600-0ec9d4da3a96/go.mod h1:4uIIEYVWTw+fDs9LVKy1CPnL6Z0XcLOjmanj7fVCIpE=
 github.com/hashicorp/hcl/v2 v2.21.0 h1:lve4q/o/2rqwYOgUg3y3V2YPyD1/zkCLGjIV74Jit14=
 github.com/hashicorp/hcl/v2 v2.21.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
 github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVWkd/RG0D2XQ=

--- a/internal/schema/refscope/scopes.go
+++ b/internal/schema/refscope/scopes.go
@@ -16,4 +16,6 @@ var (
 	ProviderScope = lang.ScopeId("provider")
 	ResourceScope = lang.ScopeId("resource")
 	VariableScope = lang.ScopeId("variable")
+
+	ComponentScope = lang.ScopeId("component")
 )

--- a/internal/schema/stacks/1.9/component_block.go
+++ b/internal/schema/stacks/1.9/component_block.go
@@ -14,6 +14,15 @@ import (
 func componentBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
 		Description: lang.Markdown("Component represents the declaration of a single component within a particular Terraform Stack. Components are the most important object in a stack configuration, just as resources are the most important object in a Terraform module: each one refers to a Terraform module that describes the infrastructure that the component is 'made of'."),
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "component"},
+				schema.LabelStep{Index: 0},
+			},
+			FriendlyName: "component",
+			ScopeId:      refscope.ComponentScope,
+			AsReference:  true,
+		},
 		Labels: []*schema.LabelSchema{
 			{
 				Name:                   "name",
@@ -32,6 +41,9 @@ func componentBlockSchema() *schema.BlockSchema {
 					IsDepKey:               true,
 					Constraint:             schema.LiteralType{Type: cty.String},
 					SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+					CompletionHooks: lang.CompletionHooks{
+						{Name: "CompleteLocalModuleSources"},
+					},
 				},
 				"inputs": {
 					Description: lang.Markdown("A mapping of module input variable names to values. The keys of this map must correspond to the Terraform variable names in the module defined by source. Can be any Terraform expression, and can refer to anything which is in scope, including input variables, component outputs, the `each` object, and provider configurations"),

--- a/schema/language_ids.go
+++ b/schema/language_ids.go
@@ -6,4 +6,5 @@ package schema
 const (
 	ModuleLanguageID    = "terraform"
 	VariablesLanguageID = "terraform-vars"
+	StackLanguageID     = "terraform-stack"
 )


### PR DESCRIPTION
This change enables the use of component references in the stack schema. This allows users to reference components in the same stack, and have the schema automatically update to reflect the available outputs of the referenced component.

Needs https://github.com/hashicorp/hcl-lang/pull/408