### PR TITLE
(TF-19343) Enable ephemeral values for variable

### DIFF
--- a/internal/schema/stacks/1.9/variable_block.go
+++ b/internal/schema/stacks/1.9/variable_block.go
@@ -42,6 +42,11 @@ func variableBlockSchema() *schema.BlockSchema {
 					IsOptional:  true,
 					Description: lang.Markdown("Description to document the purpose of the variable and what value is expected"),
 				},
+				"ephemeral": {
+					Constraint:  schema.LiteralType{Type: cty.Bool},
+					IsOptional:  true,
+					Description: lang.Markdown("Ephemeral values are not saved in the state file and are not visible in the UI"),
+				},
 				"type": {
 					Constraint:  schema.TypeDeclaration{},
 					IsOptional:  true,


### PR DESCRIPTION
This change adds a new `ephemeral` field to the variable block schema.

This is not true support for ephemeral values, but allows for validation of Stack files to pass. Actual support will come later.
