### PR TITLE
fix: fix type for provider references in component blocks

### DIFF
--- a/schema/stacks/stack_schema_merge.go
+++ b/schema/stacks/stack_schema_merge.go
@@ -192,10 +192,7 @@ func schemaForDependentComponentBlock(modMeta *tfmod.Meta, component stack.Compo
 		}
 
 		providers[addr] = &schema.AttributeSchema{
-			Constraint: schema.Reference{
-				Name:   addr,
-				OfType: cty.DynamicPseudoType,
-			},
+			Constraint: schema.Reference{OfScopeId: refscope.ProviderScope},
 		}
 	}
 


### PR DESCRIPTION
![provider_completions](https://github.com/user-attachments/assets/eeebee05-6479-4d5a-a765-86a7702c309b)
