### PR TITLE
(TF-19382) Add depends_on attribute to component block schema

### DIFF
--- a/internal/schema/stacks/1.9/component_block.go
+++ b/internal/schema/stacks/1.9/component_block.go
@@ -68,6 +68,14 @@ func componentBlockSchema() *schema.BlockSchema {
 						Elem: schema.Reference{OfScopeId: refscope.ProviderScope},
 					},
 				},
+				"depends_on": {
+					Description: lang.Markdown("Optionally specify explicit dependencies for components in a stack configuration, which must also be used when determining an order of operations for components"),
+					IsOptional:  true,
+					Constraint: schema.List{
+						// TODO: This eventually will support embedded stack references
+						Elem: schema.Reference{OfScopeId: refscope.ComponentScope},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This change adds a depends_on attribute to the component block schema. This attribute allows users to specify explicit dependencies for components in a stack configuration, which must also be used when determining an order of operations for components.
