### PR TITLE
(TF-19384) Support locals in stack and deploy configs

### DIFF
--- a/internal/schema/stacks/1.9/locals_block.go
+++ b/internal/schema/stacks/1.9/locals_block.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func localsBlockSchema() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Locals},
+		Description: lang.Markdown("Local values assigning names to expressions, so you can use these multiple times without repetition\n" +
+			"e.g. `service_name = \"forum\"`"),
+		Body: &schema.BodySchema{
+			AnyAttribute: &schema.AttributeSchema{
+				Address: &schema.AttributeAddrSchema{
+					Steps: []schema.AddrStep{
+						schema.StaticStep{Name: "local"},
+						schema.AttrNameStep{},
+					},
+					ScopeId:     refscope.LocalScope,
+					AsExprType:  true,
+					AsReference: true,
+				},
+				Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+			},
+		},
+	}
+}

--- a/internal/schema/stacks/1.9/root.go
+++ b/internal/schema/stacks/1.9/root.go
@@ -18,6 +18,7 @@ func StackSchema(_ *version.Version) *schema.BodySchema {
 			"required_providers": requiredProvidersBlockSchema(),
 			"variable":           variableBlockSchema(),
 			"output":             outputBlockSchema(),
+			"locals":             localsBlockSchema(),
 		},
 	}
 }
@@ -31,6 +32,7 @@ func DeploymentSchema(_ *version.Version) *schema.BodySchema {
 			"identity_token": identityTokenBlockSchema(),
 			"orchestrate":    orchestrateBlockSchema(),
 			"store":          storeBlockSchema(),
+			"locals":         localsBlockSchema(),
 		},
 	}
 }


### PR DESCRIPTION
This change adds support for locals in stack and deployment configuration. This also adds minimal reference support for locals, allowing go to definition and find references to work for locals.