### PR TITLE
fix: Support sensitive attribute for stacks variables

### DIFF
--- a/internal/schema/stacks/1.9/component_block.go
+++ b/internal/schema/stacks/1.9/component_block.go
@@ -50,7 +50,7 @@ func componentBlockSchema() *schema.BlockSchema {
 					IsOptional:  true,
 					Constraint: schema.Map{
 						Name: "map of input references",
-						Elem: schema.Reference{OfScopeId: refscope.ModuleScope}, // TODO: This should be refscope.InputScope ?
+						Elem: schema.AnyExpression{OfType: cty.DynamicPseudoType},
 					},
 				},
 				"version": {

--- a/internal/schema/stacks/1.9/variable_block.go
+++ b/internal/schema/stacks/1.9/variable_block.go
@@ -42,6 +42,12 @@ func variableBlockSchema() *schema.BlockSchema {
 					IsOptional:  true,
 					Description: lang.Markdown("Description to document the purpose of the variable and what value is expected"),
 				},
+				"sensitive": {
+					Constraint:   schema.LiteralType{Type: cty.Bool},
+					DefaultValue: schema.DefaultValue{Value: cty.False},
+					IsOptional:   true,
+					Description:  lang.Markdown("Whether the variable contains sensitive material and should be hidden in the UI"),
+				},
 				"ephemeral": {
 					Constraint:  schema.LiteralType{Type: cty.Bool},
 					IsOptional:  true,


### PR DESCRIPTION
This adds support for the `sensitive` attribute for stacks variables.

Based on https://github.com/hashicorp/terraform-schema/pull/400 to make it easier for me to have both fixes locally for recording a demo 😁