### PR TITLE
(TFECO-7726) Ephemeral Resources support

### DIFF
--- a/earlydecoder/decoder_test.go
+++ b/earlydecoder/decoder_test.go
@@ -79,6 +79,10 @@ resource "google_storage_bucket" "bucket" {
   name = "test-bucket"
 }
 
+ephemeral "random_password" "psst" {
+  length = 16
+}
+
 data "blah_foobar" "test" {
   name = "something"
 }
@@ -95,12 +99,14 @@ provider "grafana" {
 					{LocalName: "blah"}:    addr.NewLegacyProvider("blah"),
 					{LocalName: "google"}:  addr.NewLegacyProvider("google"),
 					{LocalName: "grafana"}: addr.NewLegacyProvider("grafana"),
+					{LocalName: "random"}:  addr.NewLegacyProvider("random"),
 				},
 				ProviderRequirements: map[tfaddr.Provider]version.Constraints{
 					addr.NewLegacyProvider("aws"):     {},
 					addr.NewLegacyProvider("blah"):    {},
 					addr.NewLegacyProvider("google"):  {},
 					addr.NewLegacyProvider("grafana"): {},
+					addr.NewLegacyProvider("random"):  {},
 				},
 				Variables:   map[string]module.Variable{},
 				Outputs:     map[string]module.Output{},

--- a/earlydecoder/ephemeral_resource.go
+++ b/earlydecoder/ephemeral_resource.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package earlydecoder
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-schema/module"
+)
+
+type ephemeralResource struct {
+	Type     string
+	Name     string
+	Provider module.ProviderRef
+}
+
+// MapKey returns a string that can be used to uniquely identify the receiver
+// in a map[string]*ephemeralResource.
+func (r *ephemeralResource) MapKey() string {
+	return fmt.Sprintf("%s.%s", r.Type, r.Name)
+}

--- a/earlydecoder/ephemeral_resource.go
+++ b/earlydecoder/ephemeral_resource.go
@@ -18,5 +18,5 @@ type ephemeralResource struct {
 // MapKey returns a string that can be used to uniquely identify the receiver
 // in a map[string]*ephemeralResource.
 func (r *ephemeralResource) MapKey() string {
-	return fmt.Sprintf("%s.%s", r.Type, r.Name)
+	return fmt.Sprintf("ephemeral.%s.%s", r.Type, r.Name)
 }

--- a/earlydecoder/schema.go
+++ b/earlydecoder/schema.go
@@ -21,6 +21,10 @@ var rootSchema = &hcl.BodySchema{
 			LabelNames: []string{"type", "name"},
 		},
 		{
+			Type:       "ephemeral",
+			LabelNames: []string{"type", "name"},
+		},
+		{
 			Type:       "data",
 			LabelNames: []string{"type", "name"},
 		},

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/hcl-lang v0.0.0-20240830144831-468c47ee72a9
 	github.com/hashicorp/hcl/v2 v2.22.0
 	github.com/hashicorp/terraform-exec v0.21.0
-	github.com/hashicorp/terraform-json v0.22.1
+	github.com/hashicorp/terraform-json v0.22.2-0.20241007092238-76bdbbf21572
 	github.com/hashicorp/terraform-registry-address v0.2.3
 	github.com/mh-cbon/go-fmt-fail v0.0.0-20160815164508-67765b3fbcb5
 	github.com/zclconf/go-cty v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/hashicorp/terraform-exec v0.21.0 h1:uNkLAe95ey5Uux6KJdua6+cv8asgILFVW
 github.com/hashicorp/terraform-exec v0.21.0/go.mod h1:1PPeMYou+KDUSSeRE9szMZ/oHf4fYUmB923Wzbq1ICg=
 github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7orfb5Ltvec=
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
+github.com/hashicorp/terraform-json v0.22.2-0.20241007092238-76bdbbf21572 h1:B7p7ZRTgmNNFZ6jQVz+FZ+/zf56047N5f6gmYKCRJOk=
+github.com/hashicorp/terraform-json v0.22.2-0.20241007092238-76bdbbf21572/go.mod h1:MHdXbBAbSg0GvzuWazEGKAn/cyNfIB7mN6y7KJN6y2c=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=
 github.com/hashicorp/terraform-registry-address v0.2.3/go.mod h1:lFHA76T8jfQteVfT7caREqguFrW3c4MFSPhZB7HHgUM=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/schema/1.10/ephemeral_block.go
+++ b/internal/schema/1.10/ephemeral_block.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
+	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ephemeralBlockSchema() *schema.BlockSchema {
+	bs := &schema.BlockSchema{
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "ephemeral"},
+				schema.LabelStep{Index: 0},
+				schema.LabelStep{Index: 1},
+			},
+			FriendlyName:         "ephemeral",
+			ScopeId:              refscope.EphemeralScope,
+			AsReference:          true,
+			DependentBodyAsData:  true,
+			InferDependentBody:   true,
+			DependentBodySelfRef: true,
+		},
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Ephemeral},
+		Labels: []*schema.LabelSchema{
+			{
+				Name:                   "type",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Type, lang.TokenModifierDependent},
+				Description:            lang.PlainText("Ephemeral Resource Type"),
+				IsDepKey:               true,
+				Completable:            true,
+			},
+			{
+				Name:                   "name",
+				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
+				Description:            lang.PlainText("Reference Name"),
+			},
+		},
+		Description: lang.PlainText("An ephemeral block declares an ephemeral resource of a given type with a given local name. The name is " +
+			"used to refer to this ephemeral resource from elsewhere in the same Terraform module, but has no significance " +
+			"outside of the scope of a module."),
+		Body: &schema.BodySchema{
+			Extensions: &schema.BodyExtensions{
+				Count:         true,
+				ForEach:       true,
+				DynamicBlocks: true,
+			},
+			Attributes: map[string]*schema.AttributeSchema{
+				"provider": {
+					Constraint:             schema.Reference{OfScopeId: refscope.ProviderScope},
+					IsOptional:             true,
+					Description:            lang.Markdown("Reference to a `provider` configuration block, e.g. `mycloud.west` or `mycloud`"),
+					IsDepKey:               true,
+					SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+				},
+				"depends_on": {
+					Constraint: schema.Set{
+						Elem: schema.OneOf{
+							schema.Reference{OfScopeId: refscope.DataScope},
+							schema.Reference{OfScopeId: refscope.ModuleScope},
+							schema.Reference{OfScopeId: refscope.ResourceScope},
+							schema.Reference{OfScopeId: refscope.EphemeralScope},
+							schema.Reference{OfScopeId: refscope.VariableScope},
+							schema.Reference{OfScopeId: refscope.LocalScope},
+						},
+					},
+					IsOptional:  true,
+					Description: lang.Markdown("Set of references to hidden dependencies, e.g. resources or data sources"),
+				},
+			},
+			Blocks: map[string]*schema.BlockSchema{
+				"lifecycle": ephemeralLifecycleBlock(),
+			},
+		},
+	}
+
+	return bs
+}
+
+func ephemeralLifecycleBlock() *schema.BlockSchema {
+	return &schema.BlockSchema{
+		Description: lang.Markdown("Lifecycle customizations to change default ephemeral resource behaviors during apply"),
+		Body: &schema.BodySchema{
+			Blocks: map[string]*schema.BlockSchema{
+				"precondition": {
+					Body: conditionBody(false),
+				},
+				"postcondition": {
+					Body: conditionBody(true),
+				},
+			},
+		},
+	}
+}
+
+func conditionBody(enableSelfRefs bool) *schema.BodySchema {
+	bs := &schema.BodySchema{
+		Attributes: map[string]*schema.AttributeSchema{
+			"condition": {
+				Constraint: schema.AnyExpression{OfType: cty.Bool},
+				IsRequired: true,
+				Description: lang.Markdown("Condition, a boolean expression that should return `true` " +
+					"if the intended assumption or guarantee is fulfilled or `false` if it is not."),
+			},
+			"error_message": {
+				Constraint: schema.AnyExpression{OfType: cty.String},
+				IsRequired: true,
+				Description: lang.Markdown("Error message to return if the `condition` isn't met " +
+					"(evaluates to `false`)."),
+			},
+		},
+	}
+
+	if enableSelfRefs {
+		bs.Extensions = &schema.BodyExtensions{
+			SelfRefs: true,
+		}
+	}
+
+	return bs
+}

--- a/internal/schema/1.10/root.go
+++ b/internal/schema/1.10/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	v1_9_mod "github.com/hashicorp/terraform-schema/internal/schema/1.9"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
 )
 
 func ModuleSchema(v *version.Version) *schema.BodySchema {
@@ -25,6 +26,25 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 		Constraint:  schema.LiteralType{Type: cty.Bool},
 		Description: lang.PlainText("Whether the value is ephemeral and should not be persisted in the state"),
 	}
+
+	bs.Blocks["ephemeral"] = ephemeralBlockSchema()
+
+	// all the depends_on attributes can refer to ephemeral blocks
+	constraint := schema.Set{
+		Elem: schema.OneOf{
+			schema.Reference{OfScopeId: refscope.DataScope},
+			schema.Reference{OfScopeId: refscope.ModuleScope},
+			schema.Reference{OfScopeId: refscope.ResourceScope},
+			schema.Reference{OfScopeId: refscope.EphemeralScope}, // This one is new, but overriding is easier than adding to each list
+			schema.Reference{OfScopeId: refscope.VariableScope},
+			schema.Reference{OfScopeId: refscope.LocalScope},
+		},
+	}
+	bs.Blocks["resource"].Body.Attributes["depends_on"].Constraint = constraint
+	bs.Blocks["data"].Body.Attributes["depends_on"].Constraint = constraint
+	bs.Blocks["output"].Body.Attributes["depends_on"].Constraint = constraint
+	bs.Blocks["module"].Body.Attributes["depends_on"].Constraint = constraint
+	bs.Blocks["check"].Body.Blocks["data"].Body.Attributes["depends_on"].Constraint = constraint
 
 	return bs
 }

--- a/internal/schema/refscope/scopes.go
+++ b/internal/schema/refscope/scopes.go
@@ -8,14 +8,15 @@ import (
 )
 
 var (
-	BuiltinScope  = lang.ScopeId("builtin")
-	DataScope     = lang.ScopeId("data")
-	LocalScope    = lang.ScopeId("local")
-	ModuleScope   = lang.ScopeId("module")
-	OutputScope   = lang.ScopeId("output")
-	ProviderScope = lang.ScopeId("provider")
-	ResourceScope = lang.ScopeId("resource")
-	VariableScope = lang.ScopeId("variable")
+	BuiltinScope   = lang.ScopeId("builtin")
+	DataScope      = lang.ScopeId("data")
+	LocalScope     = lang.ScopeId("local")
+	ModuleScope    = lang.ScopeId("module")
+	OutputScope    = lang.ScopeId("output")
+	ProviderScope  = lang.ScopeId("provider")
+	ResourceScope  = lang.ScopeId("resource")
+	EphemeralScope = lang.ScopeId("ephemeral")
+	VariableScope  = lang.ScopeId("variable")
 
 	ComponentScope     = lang.ScopeId("component")
 	IdentityTokenScope = lang.ScopeId("identity_token")

--- a/internal/schema/tokmod/token_modifier.go
+++ b/internal/schema/tokmod/token_modifier.go
@@ -14,6 +14,7 @@ var (
 	Output            = lang.SemanticTokenModifier("terraform-output")
 	Provider          = lang.SemanticTokenModifier("terraform-provider")
 	Resource          = lang.SemanticTokenModifier("terraform-resource")
+	Ephemeral         = lang.SemanticTokenModifier("terraform-ephemeral")
 	Provisioner       = lang.SemanticTokenModifier("terraform-provisioner")
 	Connection        = lang.SemanticTokenModifier("terraform-connection")
 	Variable          = lang.SemanticTokenModifier("terraform-variable")

--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -17,9 +17,10 @@ import (
 
 func ProviderSchemaFromJson(jsonSchema *tfjson.ProviderSchema, pAddr tfaddr.Provider) *ProviderSchema {
 	ps := &ProviderSchema{
-		Resources:   map[string]*schema.BodySchema{},
-		DataSources: map[string]*schema.BodySchema{},
-		Functions:   map[string]*schema.FunctionSignature{},
+		Resources:          map[string]*schema.BodySchema{},
+		EphemeralResources: map[string]*schema.BodySchema{},
+		DataSources:        map[string]*schema.BodySchema{},
+		Functions:          map[string]*schema.FunctionSignature{},
 	}
 
 	if jsonSchema.ConfigSchema != nil {
@@ -32,6 +33,11 @@ func ProviderSchemaFromJson(jsonSchema *tfjson.ProviderSchema, pAddr tfaddr.Prov
 	for rName, rSchema := range jsonSchema.ResourceSchemas {
 		ps.Resources[rName] = bodySchemaFromJson(rSchema.Block)
 		ps.Resources[rName].Detail = detailForSrcAddr(pAddr, nil)
+	}
+
+	for erName, erSchema := range jsonSchema.EphemeralResourceSchemas {
+		ps.EphemeralResources[erName] = bodySchemaFromJson(erSchema.Block)
+		ps.EphemeralResources[erName].Detail = detailForSrcAddr(pAddr, nil)
 	}
 
 	for dsName, dsSchema := range jsonSchema.DataSourceSchemas {

--- a/schema/convert_json_test.go
+++ b/schema/convert_json_test.go
@@ -23,9 +23,10 @@ func TestProviderSchemaFromJson_empty(t *testing.T) {
 
 	ps := ProviderSchemaFromJson(jsonSchema, providerAddr)
 	expectedPs := &ProviderSchema{
-		Resources:   map[string]*schema.BodySchema{},
-		DataSources: map[string]*schema.BodySchema{},
-		Functions:   map[string]*schema.FunctionSignature{},
+		Resources:          map[string]*schema.BodySchema{},
+		EphemeralResources: map[string]*schema.BodySchema{},
+		DataSources:        map[string]*schema.BodySchema{},
+		Functions:          map[string]*schema.FunctionSignature{},
 	}
 
 	if diff := cmp.Diff(expectedPs, ps, ctydebug.CmpOptions); diff != "" {
@@ -293,8 +294,9 @@ func TestProviderSchemaFromJson_basic(t *testing.T) {
 				Detail: "hashicorp/aws",
 			},
 		},
-		DataSources: map[string]*schema.BodySchema{},
-		Functions:   map[string]*schema.FunctionSignature{},
+		EphemeralResources: map[string]*schema.BodySchema{},
+		DataSources:        map[string]*schema.BodySchema{},
+		Functions:          map[string]*schema.FunctionSignature{},
 	}
 
 	if diff := cmp.Diff(expectedPs, ps, ctydebug.CmpOptions); diff != "" {
@@ -501,8 +503,9 @@ func TestProviderSchemaFromJson_nested_set_list(t *testing.T) {
 				Detail: "hashicorp/aws",
 			},
 		},
-		DataSources: map[string]*schema.BodySchema{},
-		Functions:   map[string]*schema.FunctionSignature{},
+		EphemeralResources: map[string]*schema.BodySchema{},
+		DataSources:        map[string]*schema.BodySchema{},
+		Functions:          map[string]*schema.FunctionSignature{},
 	}
 
 	if diff := cmp.Diff(expectedPs, ps, ctydebug.CmpOptions); diff != "" {
@@ -535,8 +538,9 @@ func TestProviderSchemaFromJson_function(t *testing.T) {
 			  }
 		}`,
 			ProviderSchema{
-				Resources:   map[string]*schema.BodySchema{},
-				DataSources: map[string]*schema.BodySchema{},
+				Resources:          map[string]*schema.BodySchema{},
+				EphemeralResources: map[string]*schema.BodySchema{},
+				DataSources:        map[string]*schema.BodySchema{},
 				Functions: map[string]*schema.FunctionSignature{
 					"example": {
 						Description: "Echoes given argument as result",
@@ -567,8 +571,9 @@ func TestProviderSchemaFromJson_function(t *testing.T) {
 			  }
 		}`,
 			ProviderSchema{
-				Resources:   map[string]*schema.BodySchema{},
-				DataSources: map[string]*schema.BodySchema{},
+				Resources:          map[string]*schema.BodySchema{},
+				EphemeralResources: map[string]*schema.BodySchema{},
+				DataSources:        map[string]*schema.BodySchema{},
 				Functions: map[string]*schema.FunctionSignature{
 					"example": {
 						Description: "Returns a string",
@@ -604,8 +609,9 @@ func TestProviderSchemaFromJson_function(t *testing.T) {
 			  }
 		}`,
 			ProviderSchema{
-				Resources:   map[string]*schema.BodySchema{},
-				DataSources: map[string]*schema.BodySchema{},
+				Resources:          map[string]*schema.BodySchema{},
+				EphemeralResources: map[string]*schema.BodySchema{},
+				DataSources:        map[string]*schema.BodySchema{},
 				Functions: map[string]*schema.FunctionSignature{
 					"example": {
 						Description: "Echoes given argument as result",

--- a/schema/provider_schema.go
+++ b/schema/provider_schema.go
@@ -10,10 +10,11 @@ import (
 )
 
 type ProviderSchema struct {
-	Provider    *schema.BodySchema
-	Resources   map[string]*schema.BodySchema
-	DataSources map[string]*schema.BodySchema
-	Functions   map[string]*schema.FunctionSignature
+	Provider           *schema.BodySchema
+	Resources          map[string]*schema.BodySchema
+	EphemeralResources map[string]*schema.BodySchema
+	DataSources        map[string]*schema.BodySchema
+	Functions          map[string]*schema.FunctionSignature
 }
 
 func (ps *ProviderSchema) Copy() *ProviderSchema {
@@ -29,6 +30,13 @@ func (ps *ProviderSchema) Copy() *ProviderSchema {
 		newPs.Resources = make(map[string]*schema.BodySchema, len(ps.Resources))
 		for name, rSchema := range ps.Resources {
 			newPs.Resources[name] = rSchema.Copy()
+		}
+	}
+
+	if ps.EphemeralResources != nil {
+		newPs.EphemeralResources = make(map[string]*schema.BodySchema, len(ps.EphemeralResources))
+		for name, erSchema := range ps.EphemeralResources {
+			newPs.EphemeralResources[name] = erSchema.Copy()
 		}
 	}
 
@@ -57,6 +65,9 @@ func (ps *ProviderSchema) SetProviderVersion(pAddr tfaddr.Provider, v *version.V
 	}
 	for _, rSchema := range ps.Resources {
 		rSchema.Detail = detailForSrcAddr(pAddr, v)
+	}
+	for _, erSchema := range ps.EphemeralResources {
+		erSchema.Detail = detailForSrcAddr(pAddr, v)
 	}
 	for _, dsSchema := range ps.DataSources {
 		dsSchema.Detail = detailForSrcAddr(pAddr, v)

--- a/schema/provider_schema_test.go
+++ b/schema/provider_schema_test.go
@@ -28,6 +28,16 @@ func TestProviderSchema_SetProviderVersion(t *testing.T) {
 				},
 			},
 		},
+		EphemeralResources: map[string]*schema.BodySchema{
+			"eph": {
+				Attributes: map[string]*schema.AttributeSchema{
+					"str": {
+						Constraint: schema.LiteralType{Type: cty.String},
+						IsOptional: true,
+					},
+				},
+			},
+		},
 		DataSources: map[string]*schema.BodySchema{
 			"bar": {
 				Attributes: map[string]*schema.AttributeSchema{
@@ -62,6 +72,17 @@ func TestProviderSchema_SetProviderVersion(t *testing.T) {
 		},
 		Resources: map[string]*schema.BodySchema{
 			"foo": {
+				Detail: "hashicorp/aws 1.2.5",
+				Attributes: map[string]*schema.AttributeSchema{
+					"str": {
+						Constraint: schema.LiteralType{Type: cty.String},
+						IsOptional: true,
+					},
+				},
+			},
+		},
+		EphemeralResources: map[string]*schema.BodySchema{
+			"eph": {
 				Detail: "hashicorp/aws 1.2.5",
 				Attributes: map[string]*schema.AttributeSchema{
 					"str": {

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -81,7 +81,7 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 	if mergedSchema.Blocks["resource"].DependentBody == nil {
 		mergedSchema.Blocks["resource"].DependentBody = make(map[schema.SchemaKey]*schema.BodySchema)
 	}
-	if mergedSchema.Blocks["ephemeral"].DependentBody == nil {
+	if ephemeralBlock, ok := mergedSchema.Blocks["ephemeral"]; ok && ephemeralBlock.DependentBody == nil {
 		mergedSchema.Blocks["ephemeral"].DependentBody = make(map[schema.SchemaKey]*schema.BodySchema)
 	}
 	if mergedSchema.Blocks["data"].DependentBody == nil {


### PR DESCRIPTION
- **bump terraform-json**
- **support EphemeralResources in provider schema**

### Open

- [x] Parse `ephemeral` blocks in earlydecoder and support legacy provider behaviour
- [x] Add schema for ephemeral resources
- [x] support schema merging for ephemeral resources
- [x] Test this e2e with a provider that has an ephemeral resource