### PR TITLE
Raise HCL diagnostics

### DIFF
--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -7,9 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/hashicorp/terraform-schema/stack"
 )
 
@@ -43,26 +41,11 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, map[string
 		outputs[key] = *output
 	}
 
-	var providerRequirements = make(map[string]stack.ProviderRequirement, 0)
+	providerRequirements := make(map[string]stack.ProviderRequirement, len(mod.ProviderRequirements))
 	for name, req := range mod.ProviderRequirements {
-		var src tfaddr.Provider
-
-		var err error
-		src, err = tfaddr.ParseProviderSource(req.Source)
-		if err != nil {
-			// This is handled in decodeRequiredProvidersBlock now
-			continue
-		}
-
-		constraints, err := version.NewConstraint(req.VersionConstraints)
-		if err != nil {
-			// This is handled in decodeRequiredProvidersBlock now
-			continue
-		}
-
 		providerRequirements[name] = stack.ProviderRequirement{
-			Source:             src,
-			VersionConstraints: constraints,
+			Source:             *req.Source,
+			VersionConstraints: *req.VersionConstraints,
 		}
 	}
 

--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -4,7 +4,6 @@
 package earlydecoder
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -14,9 +13,9 @@ import (
 	"github.com/hashicorp/terraform-schema/stack"
 )
 
-func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
+func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, map[string]hcl.Diagnostics) {
 	filenames := make([]string, 0)
+	sdiags := make(map[string]hcl.Diagnostics, 0)
 
 	mod := newDecodedStack()
 	for filename, f := range files {
@@ -24,7 +23,7 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagno
 
 		if isStackFilename(filename) {
 			fDiags := loadStackFromFile(f, mod)
-			diags = append(diags, fDiags...)
+			sdiags[filename] = fDiags // map of diags
 		}
 	}
 
@@ -52,21 +51,23 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagno
 		var err error
 		src, err = tfaddr.ParseProviderSource(req.Source)
 		if err != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Unable to parse provider source for %q", name),
-				Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, req.Source),
-			})
+			// TODO
+			// diags = append(diags, &hcl.Diagnostic{
+			// 	Severity: hcl.DiagError,
+			// 	Summary:  fmt.Sprintf("Unable to parse provider source for %q", name),
+			// 	Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, req.Source),
+			// })
 			continue
 		}
 
 		constraints, err := version.NewConstraint(req.VersionConstraints)
 		if err != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
-				Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", req.VersionConstraints, err),
-			})
+			// TODO
+			// diags = append(diags, &hcl.Diagnostic{
+			// 	Severity: hcl.DiagError,
+			// 	Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
+			// 	Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", req.VersionConstraints, err),
+			// })
 			continue
 		}
 
@@ -83,7 +84,7 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, hcl.Diagno
 		Variables:            variables,
 		Outputs:              outputs,
 		ProviderRequirements: providerRequirements,
-	}, diags
+	}, sdiags
 }
 
 func isStackFilename(name string) bool {

--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -22,8 +22,7 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, map[string
 		filenames = append(filenames, filename)
 
 		if isStackFilename(filename) {
-			fDiags := loadStackFromFile(f, mod)
-			sdiags[filename] = fDiags // map of diags
+			sdiags[filename] = loadStackFromFile(f, mod)
 		}
 	}
 
@@ -51,23 +50,13 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, map[string
 		var err error
 		src, err = tfaddr.ParseProviderSource(req.Source)
 		if err != nil {
-			// TODO
-			// diags = append(diags, &hcl.Diagnostic{
-			// 	Severity: hcl.DiagError,
-			// 	Summary:  fmt.Sprintf("Unable to parse provider source for %q", name),
-			// 	Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, req.Source),
-			// })
+			// This is handled in decodeRequiredProvidersBlock now
 			continue
 		}
 
 		constraints, err := version.NewConstraint(req.VersionConstraints)
 		if err != nil {
-			// TODO
-			// diags = append(diags, &hcl.Diagnostic{
-			// 	Severity: hcl.DiagError,
-			// 	Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
-			// 	Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", req.VersionConstraints, err),
-			// })
+			// This is handled in decodeRequiredProvidersBlock now
 			continue
 		}
 

--- a/earlydecoder/stacks/decoder_test.go
+++ b/earlydecoder/stacks/decoder_test.go
@@ -21,7 +21,7 @@ type testCase struct {
 	name          string
 	cfg           string
 	expectedMeta  *stack.Meta
-	expectedError hcl.Diagnostics
+	expectedError map[string]hcl.Diagnostics
 }
 
 var customComparer = []cmp.Option{
@@ -44,7 +44,7 @@ func TestLoadStack(t *testing.T) {
 				Outputs:              map[string]stack.Output{},
 				ProviderRequirements: map[string]stack.ProviderRequirement{},
 			},
-			nil,
+			map[string]hcl.Diagnostics{"test.tfstack.hcl": nil},
 		},
 		{
 			"complete component",
@@ -69,7 +69,7 @@ func TestLoadStack(t *testing.T) {
 				Outputs:              map[string]stack.Output{},
 				ProviderRequirements: map[string]stack.ProviderRequirement{},
 			},
-			nil,
+			map[string]hcl.Diagnostics{"test.tfstack.hcl": nil},
 		},
 		{
 			"complete required_providers",
@@ -94,7 +94,7 @@ func TestLoadStack(t *testing.T) {
 					"random": {Source: tfaddr.MustParseProviderSource("hashicorp/random"), VersionConstraints: version.MustConstraints(version.NewConstraint("~> 3.5.1"))},
 				},
 			},
-			nil,
+			map[string]hcl.Diagnostics{"test.tfstack.hcl": nil},
 		},
 	}
 
@@ -112,9 +112,11 @@ func runTestCases(testCases []testCase, t *testing.T, path string) {
 				"test.tfstack.hcl": f,
 			}
 
-			meta, diags := LoadStack(path, files)
+			// LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, map[string]hcl.Diagnostics)
+			var fdiags map[string]hcl.Diagnostics
+			meta, fdiags := LoadStack(path, files)
 
-			if diff := cmp.Diff(tc.expectedError, diags, customComparer...); diff != "" {
+			if diff := cmp.Diff(tc.expectedError, fdiags, customComparer...); diff != "" {
 				t.Fatalf("expected errors doesn't match: %s", diff)
 			}
 

--- a/earlydecoder/stacks/load_stack.go
+++ b/earlydecoder/stacks/load_stack.go
@@ -89,9 +89,9 @@ func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
 				if _, exists := ds.ProviderRequirements[name]; !exists {
 					ds.ProviderRequirements[name] = req
 				} else {
-					if req.Source != "" {
+					if req.Source != nil {
 						source := ds.ProviderRequirements[name].Source
-						if source != "" && source != req.Source {
+						if source != nil && source != req.Source {
 							diags = append(diags, &hcl.Diagnostic{
 								Severity: hcl.DiagError,
 								Summary:  "Multiple provider source attributes",
@@ -103,9 +103,9 @@ func loadStackFromFile(file *hcl.File, ds *decodedStack) hcl.Diagnostics {
 						}
 					}
 
-					if req.VersionConstraints != "" {
+					if req.VersionConstraints != nil {
 						existingVersionConstraints := ds.ProviderRequirements[name].VersionConstraints
-						if existingVersionConstraints != "" && existingVersionConstraints != req.VersionConstraints {
+						if existingVersionConstraints != nil && existingVersionConstraints != req.VersionConstraints {
 							diags = append(diags, &hcl.Diagnostic{
 								Severity: hcl.DiagError,
 								Summary:  "Multiple provider version constraints",

--- a/earlydecoder/stacks/provider_requirements.go
+++ b/earlydecoder/stacks/provider_requirements.go
@@ -68,7 +68,6 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 					pr.VersionConstraints = parsedVersion.AsString()
 					_, err := version.NewConstraint(pr.VersionConstraints)
 					if err != nil {
-						// TODO
 						diags = append(diags, &hcl.Diagnostic{
 							Severity: hcl.DiagError,
 							Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
@@ -102,7 +101,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 							Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, pr.Source),
 							Subject:  attr.Expr.Range().Ptr(),
 						})
-						// continue
+						continue
 					}
 				}
 			}

--- a/earlydecoder/stacks/provider_requirements.go
+++ b/earlydecoder/stacks/provider_requirements.go
@@ -14,8 +14,8 @@ import (
 )
 
 type providerRequirement struct {
-	Source             string
-	VersionConstraints string
+	Source             *tfaddr.Provider
+	VersionConstraints *version.Constraints
 }
 
 func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequirement, hcl.Diagnostics) {
@@ -65,8 +65,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 					continue
 				}
 				if !parsedVersion.IsNull() {
-					pr.VersionConstraints = parsedVersion.AsString()
-					_, err := version.NewConstraint(pr.VersionConstraints)
+					constraints, err := version.NewConstraint(parsedVersion.AsString())
 					if err != nil {
 						diags = append(diags, &hcl.Diagnostic{
 							Severity: hcl.DiagError,
@@ -76,6 +75,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 						})
 						continue
 					}
+					pr.VersionConstraints = &constraints
 				}
 
 			case "source":
@@ -91,9 +91,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 				}
 
 				if !source.IsNull() {
-					pr.Source = source.AsString()
-
-					_, err := tfaddr.ParseProviderSource(pr.Source)
+					src, err := tfaddr.ParseProviderSource(source.AsString())
 					if err != nil {
 						diags = append(diags, &hcl.Diagnostic{
 							Severity: hcl.DiagError,
@@ -103,6 +101,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 						})
 						continue
 					}
+					pr.Source = &src
 				}
 			}
 

--- a/earlydecoder/stacks/provider_requirements.go
+++ b/earlydecoder/stacks/provider_requirements.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/go-version"
 )
 
 type providerRequirement struct {
@@ -51,8 +54,8 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 
 			switch key.AsString() {
 			case "version":
-				version, valDiags := kv.Value.Value(nil)
-				if valDiags.HasErrors() || !version.Type().Equals(cty.String) {
+				parsedVersion, valDiags := kv.Value.Value(nil)
+				if valDiags.HasErrors() || !parsedVersion.Type().Equals(cty.String) {
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  "Unsuitable value type",
@@ -61,8 +64,19 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 					})
 					continue
 				}
-				if !version.IsNull() {
-					pr.VersionConstraints = version.AsString()
+				if !parsedVersion.IsNull() {
+					pr.VersionConstraints = parsedVersion.AsString()
+					_, err := version.NewConstraint(pr.VersionConstraints)
+					if err != nil {
+						// TODO
+						diags = append(diags, &hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
+							Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", pr.VersionConstraints, err),
+							Subject:  attr.Expr.Range().Ptr(),
+						})
+						continue
+					}
 				}
 
 			case "source":
@@ -79,6 +93,17 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 
 				if !source.IsNull() {
 					pr.Source = source.AsString()
+
+					_, err := tfaddr.ParseProviderSource(pr.Source)
+					if err != nil {
+						diags = append(diags, &hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  fmt.Sprintf("Unable to parse provider source for %q", name),
+							Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, pr.Source),
+							Subject:  attr.Expr.Range().Ptr(),
+						})
+						// continue
+					}
 				}
 			}
 

--- a/earlydecoder/stacks/schema.go
+++ b/earlydecoder/stacks/schema.go
@@ -82,11 +82,3 @@ var outputSchema = &hcl.BodySchema{
 		},
 	},
 }
-
-var deploymentSchema = &hcl.BodySchema{
-	Attributes: []hcl.AttributeSchema{
-		{
-			Name: "inputs",
-		},
-	},
-}

--- a/earlydecoder/stacks/schema.go
+++ b/earlydecoder/stacks/schema.go
@@ -27,23 +27,6 @@ var rootSchema = &hcl.BodySchema{
 	},
 }
 
-var deploymentRootSchema = &hcl.BodySchema{
-	Blocks: []hcl.BlockHeaderSchema{
-		{
-			Type:       "deployment",
-			LabelNames: []string{"name"},
-		},
-		{
-			Type:       "store",
-			LabelNames: []string{"type", "name"},
-		},
-		{
-			Type:       "orchestrate",
-			LabelNames: []string{"type", "name"},
-		},
-	},
-}
-
 var componentSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{


### PR DESCRIPTION
This commit raises HCL diagnostics discovered during early decoding of the stack files. Previously the diagnostics were appended to a slice of diagnostics, which did not track which file it refered to. Now they are stored in a map of diagnostics, where the key is the filename of the stack file.
