### PR TITLE
Fix parsing provider requirements

### DIFF
--- a/earlydecoder/stacks/decoder.go
+++ b/earlydecoder/stacks/decoder.go
@@ -43,6 +43,10 @@ func LoadStack(path string, files map[string]*hcl.File) (*stack.Meta, map[string
 
 	providerRequirements := make(map[string]stack.ProviderRequirement, len(mod.ProviderRequirements))
 	for name, req := range mod.ProviderRequirements {
+		if req.Source == nil || req.VersionConstraints == nil {
+			continue
+		}
+
 		providerRequirements[name] = stack.ProviderRequirement{
 			Source:             *req.Source,
 			VersionConstraints: *req.VersionConstraints,

--- a/earlydecoder/stacks/provider_requirements.go
+++ b/earlydecoder/stacks/provider_requirements.go
@@ -70,7 +70,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 						diags = append(diags, &hcl.Diagnostic{
 							Severity: hcl.DiagError,
 							Summary:  fmt.Sprintf("Unable to parse %q provider requirements", name),
-							Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", pr.VersionConstraints, err),
+							Detail:   fmt.Sprintf("Constraint %q is not a valid constraint: %s", parsedVersion.AsString(), err),
 							Subject:  attr.Expr.Range().Ptr(),
 						})
 						continue
@@ -96,7 +96,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (map[string]*providerRequire
 						diags = append(diags, &hcl.Diagnostic{
 							Severity: hcl.DiagError,
 							Summary:  fmt.Sprintf("Unable to parse provider source for %q", name),
-							Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, pr.Source),
+							Detail:   fmt.Sprintf("%q provider source (%q) is not a valid source string", name, source.AsString()),
 							Subject:  attr.Expr.Range().Ptr(),
 						})
 						continue


### PR DESCRIPTION
The provider requirements parsing code was not checking if the source
or version constraints were nil before trying to access them. This
change adds a check to ensure that both are present before trying to
access them.
