### PR TITLE
(TFECO-7774) Add completion for orchestrate block types

### DIFF
--- a/internal/schema/refscope/scopes.go
+++ b/internal/schema/refscope/scopes.go
@@ -22,5 +22,4 @@ var (
 	IdentityTokenScope = lang.ScopeId("identity_token")
 	StoreScope         = lang.ScopeId("store")
 	OrchestrateContext = lang.ScopeId("orchestrate_context")
-	Orchestrate        = lang.ScopeId("orchestrate")
 )

--- a/internal/schema/refscope/scopes.go
+++ b/internal/schema/refscope/scopes.go
@@ -22,4 +22,5 @@ var (
 	IdentityTokenScope = lang.ScopeId("identity_token")
 	StoreScope         = lang.ScopeId("store")
 	OrchestrateContext = lang.ScopeId("orchestrate_context")
+	Orchestrate        = lang.ScopeId("orchestrate")
 )

--- a/internal/schema/stacks/1.9/orchestrate_block.go
+++ b/internal/schema/stacks/1.9/orchestrate_block.go
@@ -6,7 +6,6 @@ package schema
 import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
-	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -14,17 +13,6 @@ import (
 func orchestrateBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
 		Description: lang.PlainText("Defines an orchestration rule, such as a rule for when to auto-approve one or more deployments in the stack to be evaluated after a plan or apply operation. These rules allow you to define the behavior of various aspects of the stack in code, and make managing large numbers of deployments more manageable. The block labels include the rule type and the rule name, which together must be unique within the stack"),
-		Address: &schema.BlockAddrSchema{
-			Steps: []schema.AddrStep{
-				schema.StaticStep{Name: "orchestrate"},
-				schema.LabelStep{Index: 0},
-				schema.LabelStep{Index: 1},
-			},
-			FriendlyName:             "orchestrate",
-			ScopeId:                  refscope.Orchestrate,
-			AsReference:              true,
-			SupportUnknownNestedRefs: true,
-		},
 		Labels: []*schema.LabelSchema{
 			{
 				Name:                   "type",
@@ -47,14 +35,14 @@ func orchestrateBlockSchema() *schema.BlockSchema {
 					{Index: 0, Value: "auto_approve"},
 				},
 			}): {
-				// TODO: determine if we need to add any attributes here or Body suffices
+				// auto_approve does not have any additional attributes
 			},
 			schema.NewSchemaKey(schema.DependencyKeys{
 				Labels: []schema.LabelDependent{
 					{Index: 0, Value: "replan"},
 				},
 			}): {
-				// TODO: determine if we need to add any attributes here or Body suffices
+				// replan does not have any additional attributes
 			},
 		},
 		Body: &schema.BodySchema{

--- a/internal/schema/stacks/1.9/orchestrate_block.go
+++ b/internal/schema/stacks/1.9/orchestrate_block.go
@@ -6,6 +6,7 @@ package schema
 import (
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -13,6 +14,17 @@ import (
 func orchestrateBlockSchema() *schema.BlockSchema {
 	return &schema.BlockSchema{
 		Description: lang.PlainText("Defines an orchestration rule, such as a rule for when to auto-approve one or more deployments in the stack to be evaluated after a plan or apply operation. These rules allow you to define the behavior of various aspects of the stack in code, and make managing large numbers of deployments more manageable. The block labels include the rule type and the rule name, which together must be unique within the stack"),
+		Address: &schema.BlockAddrSchema{
+			Steps: []schema.AddrStep{
+				schema.StaticStep{Name: "orchestrate"},
+				schema.LabelStep{Index: 0},
+				schema.LabelStep{Index: 1},
+			},
+			FriendlyName:             "orchestrate",
+			ScopeId:                  refscope.Orchestrate,
+			AsReference:              true,
+			SupportUnknownNestedRefs: true,
+		},
 		Labels: []*schema.LabelSchema{
 			{
 				Name:                   "type",
@@ -27,6 +39,22 @@ func orchestrateBlockSchema() *schema.BlockSchema {
 				Name:                   "name",
 				SemanticTokenModifiers: lang.SemanticTokenModifiers{tokmod.Name},
 				Description:            lang.PlainText("Rule Name"),
+			},
+		},
+		DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Labels: []schema.LabelDependent{
+					{Index: 0, Value: "auto_approve"},
+				},
+			}): {
+				// TODO: determine if we need to add any attributes here or Body suffices
+			},
+			schema.NewSchemaKey(schema.DependencyKeys{
+				Labels: []schema.LabelDependent{
+					{Index: 0, Value: "replan"},
+				},
+			}): {
+				// TODO: determine if we need to add any attributes here or Body suffices
 			},
 		},
 		Body: &schema.BodySchema{


### PR DESCRIPTION
This commit adds completion for orchestrate block types. The supported types are auto_approve and replan.
