### PR TITLE
Update list of available Terraform versions

### DIFF
--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,10 +7,17 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.10.0-beta1"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.10.2"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.11.0-alpha20241211")),
 		version.Must(version.NewVersion("1.11.0-alpha20241106")),
+		version.Must(version.NewVersion("1.10.2")),
+		version.Must(version.NewVersion("1.10.1")),
+		version.Must(version.NewVersion("1.10.0")),
+		version.Must(version.NewVersion("1.10.0-rc3")),
+		version.Must(version.NewVersion("1.10.0-rc2")),
+		version.Must(version.NewVersion("1.10.0-rc1")),
 		version.Must(version.NewVersion("1.10.0-beta1")),
 		version.Must(version.NewVersion("1.10.0-alpha20241023")),
 		version.Must(version.NewVersion("1.10.0-alpha20241009")),


### PR DESCRIPTION
After the 1.10 stable release, we can regenerate the list of available Terraform versions and make sure we have the latest as a stable version.