### PR TITLE
(TFECO-7724) Parse and detect write only attributes

### DIFF
--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -122,6 +122,7 @@ func convertAttributesFromJson(attributes map[string]*tfjson.SchemaAttribute) ma
 			IsOptional:   attr.Optional,
 			IsRequired:   attr.Required,
 			IsSensitive:  attr.Sensitive,
+			IsWriteOnly:  attr.WriteOnly,
 			Constraint:   exprConstraintFromSchemaAttribute(attr),
 		}
 	}
@@ -326,6 +327,7 @@ func convertJsonAttributesToObjectConstraint(attrs map[string]*tfjson.SchemaAttr
 			IsComputed:   attr.Computed,
 			IsOptional:   attr.Optional,
 			IsRequired:   attr.Required,
+			IsWriteOnly:  attr.WriteOnly,
 			Constraint:   exprConstraintFromSchemaAttribute(attr),
 		}
 	}


### PR DESCRIPTION
This change adds the `IsWriteOnly` field to the `Attribute` struct in the schema package. This field is set to `true` if the attribute is marked as write only in the provider schema.
