### PR TITLE
Update schema for dynamic module sources

### DIFF
--- a/internal/schema/1.15/module_block.go
+++ b/internal/schema/1.15/module_block.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func patchModuleBlockSchema(bs *schema.BlockSchema) *schema.BlockSchema {
+	bs.Body.Attributes["source"] = &schema.AttributeSchema{
+		Constraint: schema.AnyExpression{OfType: cty.String},
+		Description: lang.Markdown("Source where to load the module from, " +
+			"a local directory (e.g. `./module`) or a remote address - e.g. " +
+			"`hashicorp/consul/aws` (Terraform Registry address) or " +
+			"`github.com/hashicorp/example` (GitHub)"),
+		IsRequired:             true,
+		IsDepKey:               true,
+		SemanticTokenModifiers: lang.SemanticTokenModifiers{lang.TokenModifierDependent},
+		CompletionHooks: lang.CompletionHooks{
+			{Name: "CompleteLocalModuleSources"},
+			{Name: "CompleteRegistryModuleSources"},
+		},
+	}
+
+	bs.Body.Attributes["version"] = &schema.AttributeSchema{
+		Constraint: schema.AnyExpression{OfType: cty.String},
+		IsOptional: true,
+		Description: lang.Markdown("Constraint to set the version of the module, e.g. `~> 1.0`." +
+			" Only applicable to modules in a module registry."),
+		CompletionHooks: lang.CompletionHooks{
+			{Name: "CompleteRegistryModuleVersions"},
+		},
+	}
+
+	return bs
+}

--- a/internal/schema/1.15/root.go
+++ b/internal/schema/1.15/root.go
@@ -15,6 +15,7 @@ func ModuleSchema(v *version.Version) *schema.BodySchema {
 
 	bs.Blocks["variable"] = patchVariableBlockSchema(bs.Blocks["variable"])
 	bs.Blocks["output"] = patchOutputBlockSchema(bs.Blocks["output"])
+	bs.Blocks["module"] = patchModuleBlockSchema(bs.Blocks["module"])
 
 	return bs
 }

--- a/internal/schema/1.15/variable_block.go
+++ b/internal/schema/1.15/variable_block.go
@@ -16,5 +16,12 @@ func patchVariableBlockSchema(bs *schema.BlockSchema) *schema.BlockSchema {
 		Description: lang.Markdown("Setting this value marks the variable as deprecated. The string value provided should describe the reason for deprecation and suggest an alternative. Any usage of a deprecated variable will result in a warning being emitted to the user."),
 	}
 
+	bs.Body.Attributes["const"] = &schema.AttributeSchema{
+		Constraint:   schema.LiteralType{Type: cty.Bool},
+		DefaultValue: schema.DefaultValue{Value: cty.False},
+		IsOptional:   true,
+		Description:  lang.Markdown("Whether the variable is a constant, meaning it can be used during early stages of configuration evaluation, e.g. init."),
+	}
+
 	return bs
 }


### PR DESCRIPTION
This PR updates the `variable` and `module` block to support the new dynamic module sources landing in Terraform 1.15.

It updates the `version` and `source` fields of module blocks from `LiteralType` to `AnyExpression` to allow references and string interpolation. 

* https://github.com/hashicorp/terraform/pull/38217 has more details and syntax examples

**Note**: This PR only updates the schema to improve the `source` attribute completion results. As soon as someone is using a dynamic module source, the completion for module inputs and output will stop working. To support the feature end to end, terraform-ls needs to implement some kind of expression evaluation to be able to match an interpolated string to a module directory on disk.

## UX
<img width="1604" height="314" alt="CleanShot 2026-03-05 at 12 14 26@2x" src="https://github.com/user-attachments/assets/6609a892-1d66-4183-b3ba-c8ccd847a25a" />

<img width="1266" height="312" alt="CleanShot 2026-03-05 at 12 14 43@2x" src="https://github.com/user-attachments/assets/cf2e7ffd-7b4d-4c1e-9684-caabb4bcb4d5" />

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [x] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
