### PR TITLE
Resolve Terraform docs links in Markdown descriptions

### DIFF
--- a/schema/convert_json.go
+++ b/schema/convert_json.go
@@ -354,7 +354,7 @@ func markupContent(value string, kind tfjson.SchemaDescriptionKind) lang.MarkupC
 	}
 	switch kind {
 	case tfjson.SchemaDescriptionKindMarkdown:
-		return lang.Markdown(value)
+		return lang.Markdown(resolveTerraformMarkdownLinks(value))
 	case tfjson.SchemaDescriptionKindPlain:
 		return lang.PlainText(value)
 	}
@@ -435,7 +435,7 @@ func functionSignatureFromJson(fnSig *tfjson.FunctionSignature) *schema.Function
 	}
 
 	return &schema.FunctionSignature{
-		Description: fnSig.Description,
+		Description: resolveTerraformMarkdownLinks(fnSig.Description),
 		ReturnType:  fnSig.ReturnType,
 		Params:      params,
 		VarParam:    varParam,
@@ -450,7 +450,7 @@ func convertParameterFromJson(param *tfjson.FunctionParameter) *function.Paramet
 	return &function.Parameter{
 		Name:        param.Name,
 		Type:        param.Type,
-		Description: param.Description,
+		Description: resolveTerraformMarkdownLinks(param.Description),
 		AllowNull:   param.IsNullable,
 	}
 }

--- a/schema/convert_json_test.go
+++ b/schema/convert_json_test.go
@@ -645,6 +645,47 @@ func TestProviderSchemaFromJson_function(t *testing.T) {
 				ActionResources: map[string]*schema.BodySchema{},
 			},
 		},
+		{
+			"with Terraform docs link",
+			`{
+			"functions": {
+				"example": {
+				  "description": "Marks values like [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).",
+				  "summary": "Example function",
+				  "return_type": "string",
+				  "parameters": [
+					{
+					  "name": "input",
+					  "description": "See [type constraints](/terraform/language/expressions/type-constraints).",
+					  "type": "string"
+					}
+				  ]
+				}
+			  }
+		}`,
+			ProviderSchema{
+				Resources:          map[string]*schema.BodySchema{},
+				EphemeralResources: map[string]*schema.BodySchema{},
+				DataSources:        map[string]*schema.BodySchema{},
+				Functions: map[string]*schema.FunctionSignature{
+					"example": {
+						Description: "Marks values like [sensitive input variables](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output).",
+						Detail:      "hashicorp/aws",
+						ReturnType:  cty.String,
+						Params: []function.Parameter{
+							{
+								Name:        "input",
+								Description: "See [type constraints](https://developer.hashicorp.com/terraform/language/expressions/type-constraints).",
+								Type:        cty.String,
+							},
+						},
+						VarParam: nil,
+					},
+				},
+				ListResources:   map[string]*schema.BodySchema{},
+				ActionResources: map[string]*schema.BodySchema{},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/schema/functions.go
+++ b/schema/functions.go
@@ -20,23 +20,23 @@ import (
 func FunctionsForVersion(v *version.Version) (map[string]schema.FunctionSignature, error) {
 	ver := v.Core()
 	if ver.GreaterThanOrEqual(v1_4) {
-		return funcs_generated.Functions(ver), nil
+		return resolveFunctionMarkdownLinks(funcs_generated.Functions(ver)), nil
 	}
 	if ver.GreaterThanOrEqual(v1_3) {
-		return funcs_v1_3.Functions(ver), nil
+		return resolveFunctionMarkdownLinks(funcs_v1_3.Functions(ver)), nil
 	}
 	if ver.GreaterThanOrEqual(v0_15) {
-		return funcs_v0_15.Functions(ver), nil
+		return resolveFunctionMarkdownLinks(funcs_v0_15.Functions(ver)), nil
 	}
 	if ver.GreaterThanOrEqual(v0_14) {
-		return funcs_v0_14.Functions(ver), nil
+		return resolveFunctionMarkdownLinks(funcs_v0_14.Functions(ver)), nil
 	}
 	if ver.GreaterThanOrEqual(v0_13) {
-		return funcs_v0_13.Functions(ver), nil
+		return resolveFunctionMarkdownLinks(funcs_v0_13.Functions(ver)), nil
 	}
 
 	// Return the 0.12 functions for any version <= 0.12
-	return funcs_v0_12.Functions(ver), nil
+	return resolveFunctionMarkdownLinks(funcs_v0_12.Functions(ver)), nil
 }
 
 func FunctionsForConstraint(vc version.Constraints) (map[string]schema.FunctionSignature, error) {

--- a/schema/functions_test.go
+++ b/schema/functions_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+)
+
+func TestFunctionsForVersion_resolvesTerraformMarkdownLinks(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+	}{
+		{
+			name:    "pre product path",
+			version: "1.5.0",
+		},
+		{
+			name:    "with product path",
+			version: "1.10.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			functions, err := FunctionsForVersion(version.Must(version.NewVersion(tc.version)))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sensitiveDescription := functions["sensitive"].Description
+			if !strings.Contains(sensitiveDescription, "[sensitive input variables](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output)") {
+				t.Fatalf("sensitive description did not include absolute Terraform docs link: %q", sensitiveDescription)
+			}
+		})
+	}
+}

--- a/schema/markdown_links.go
+++ b/schema/markdown_links.go
@@ -1,0 +1,66 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"regexp"
+	"strings"
+
+	hclschema "github.com/hashicorp/hcl-lang/schema"
+)
+
+const (
+	developerDocsBaseURL = "https://developer.hashicorp.com"
+	terraformDocsBaseURL = developerDocsBaseURL + "/terraform"
+)
+
+var markdownInlineRootLink = regexp.MustCompile(`(\]\()(/[^)\s]+)([^)]*\))`)
+var terraformDocsPathPrefixes = []string{
+	"/cli/",
+	"/commands/",
+	"/cloud-docs/",
+	"/internals/",
+	"/language/",
+}
+
+func resolveFunctionMarkdownLinks(functions map[string]hclschema.FunctionSignature) map[string]hclschema.FunctionSignature {
+	normalized := make(map[string]hclschema.FunctionSignature, len(functions))
+	for name, fSig := range functions {
+		fCopy := *fSig.Copy()
+		fCopy.Description = resolveTerraformMarkdownLinks(fCopy.Description)
+		for i := range fCopy.Params {
+			fCopy.Params[i].Description = resolveTerraformMarkdownLinks(fCopy.Params[i].Description)
+		}
+		if fCopy.VarParam != nil {
+			fCopy.VarParam.Description = resolveTerraformMarkdownLinks(fCopy.VarParam.Description)
+		}
+		normalized[name] = fCopy
+	}
+
+	return normalized
+}
+
+func resolveTerraformMarkdownLinks(markdown string) string {
+	return markdownInlineRootLink.ReplaceAllStringFunc(markdown, func(link string) string {
+		matches := markdownInlineRootLink.FindStringSubmatch(link)
+		if len(matches) != 4 {
+			return link
+		}
+
+		return matches[1] + absoluteTerraformDocsURL(matches[2]) + matches[3]
+	})
+}
+
+func absoluteTerraformDocsURL(href string) string {
+	if strings.HasPrefix(href, "/terraform/") {
+		return developerDocsBaseURL + href
+	}
+	for _, prefix := range terraformDocsPathPrefixes {
+		if strings.HasPrefix(href, prefix) {
+			return terraformDocsBaseURL + href
+		}
+	}
+
+	return href
+}

--- a/schema/markdown_links_test.go
+++ b/schema/markdown_links_test.go
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl-lang/lang"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+func TestResolveTerraformMarkdownLinks(t *testing.T) {
+	testCases := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "adds terraform product path",
+			markdown: "[sensitive input variables](/language/values/variables#suppressing-values-in-cli-output)",
+			expected: "[sensitive input variables](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output)",
+		},
+		{
+			name:     "keeps existing terraform product path",
+			markdown: "[sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output)",
+			expected: "[sensitive input variables](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output)",
+		},
+		{
+			name:     "preserves absolute links",
+			markdown: "[Terraform](https://developer.hashicorp.com/terraform)",
+			expected: "[Terraform](https://developer.hashicorp.com/terraform)",
+		},
+		{
+			name:     "preserves non-root relative links",
+			markdown: "[the main provider documentation](../index.html)",
+			expected: "[the main provider documentation](../index.html)",
+		},
+		{
+			name:     "preserves other root relative links",
+			markdown: "[provider docs](/docs/providers/aws/index.html)",
+			expected: "[provider docs](/docs/providers/aws/index.html)",
+		},
+		{
+			name:     "preserves fragment links",
+			markdown: "[details](#details)",
+			expected: "[details](#details)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := resolveTerraformMarkdownLinks(tc.markdown)
+			if actual != tc.expected {
+				t.Fatalf("unexpected markdown\nexpected: %q\nactual:   %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestMarkupContent_resolvesTerraformMarkdownLinks(t *testing.T) {
+	content := markupContent("[sensitive input variables](/language/values/variables#suppressing-values-in-cli-output)", tfjson.SchemaDescriptionKindMarkdown)
+
+	if content.Kind != lang.MarkdownKind {
+		t.Fatalf("unexpected markup kind: %s", content.Kind)
+	}
+
+	expected := "[sensitive input variables](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output)"
+	if content.Value != expected {
+		t.Fatalf("unexpected markup content\nexpected: %q\nactual:   %q", expected, content.Value)
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve Terraform docs root-relative links in Markdown descriptions during JSON schema conversion.
- Normalize core function descriptions and parameter descriptions before returning function signatures.
- Leave non-Terraform relative links, such as provider-local docs paths, untouched.

Closes #323

## Testing
- go test ./...