### PR TITLE
Regenerate Teraform versions

### DIFF
--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,13 +7,33 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.14.5"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.15.6"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.16.0-alpha20260603")),
+		version.Must(version.NewVersion("1.16.0-alpha20260513")),
+		version.Must(version.NewVersion("1.15.6")),
+		version.Must(version.NewVersion("1.15.5")),
+		version.Must(version.NewVersion("1.15.4")),
+		version.Must(version.NewVersion("1.15.3")),
+		version.Must(version.NewVersion("1.15.2")),
+		version.Must(version.NewVersion("1.15.1")),
+		version.Must(version.NewVersion("1.15.0")),
+		version.Must(version.NewVersion("1.15.0-rc4")),
+		version.Must(version.NewVersion("1.15.0-rc3")),
+		version.Must(version.NewVersion("1.15.0-rc2")),
+		version.Must(version.NewVersion("1.15.0-rc1")),
+		version.Must(version.NewVersion("1.15.0-beta2")),
+		version.Must(version.NewVersion("1.15.0-beta1")),
+		version.Must(version.NewVersion("1.15.0-alpha20260304")),
 		version.Must(version.NewVersion("1.15.0-alpha20260218")),
 		version.Must(version.NewVersion("1.15.0-alpha20260204")),
 		version.Must(version.NewVersion("1.15.0-alpha20251203")),
 		version.Must(version.NewVersion("1.15.0-alpha20251119")),
+		version.Must(version.NewVersion("1.14.9")),
+		version.Must(version.NewVersion("1.14.8")),
+		version.Must(version.NewVersion("1.14.7")),
+		version.Must(version.NewVersion("1.14.6")),
 		version.Must(version.NewVersion("1.14.5")),
 		version.Must(version.NewVersion("1.14.4")),
 		version.Must(version.NewVersion("1.14.3")),


### PR DESCRIPTION
This PR extends the list of supported Terraform versions with all the latest one's. Without this the lastest schema changes are not visible by default.

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
