### PR TITLE
Add `type` attribute to 1.15 output blocks

### DIFF
--- a/internal/schema/1.15/output_block.go
+++ b/internal/schema/1.15/output_block.go
@@ -15,6 +15,11 @@ func patchOutputBlockSchema(bs *schema.BlockSchema) *schema.BlockSchema {
 		IsOptional:  true,
 		Description: lang.Markdown("Setting this value marks the output as deprecated. The string value provided should describe the reason for deprecation and suggest an alternative. Any usage of a deprecated output will result in a warning being emitted to the user."),
 	}
+	bs.Body.Attributes["type"] = &schema.AttributeSchema{
+		Constraint:  schema.TypeDeclaration{},
+		IsOptional:  true,
+		Description: lang.Markdown("Type constraint restricting the type of value to accept, e.g. `string` or `list(string)`"),
+	}
 
 	return bs
 }


### PR DESCRIPTION
Type constraints for output blocks were added in Terraform 1.15:

* https://github.com/hashicorp/terraform/pull/36411

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
