### PR TITLE
Added: attribute failure_tolerance and eager_plan to deployment_group

### DIFF
--- a/internal/schema/stacks/1.9/deployment_group_block.go
+++ b/internal/schema/stacks/1.9/deployment_group_block.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl-lang/schema"
 	"github.com/hashicorp/terraform-schema/internal/schema/refscope"
 	"github.com/hashicorp/terraform-schema/internal/schema/tokmod"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func deploymentGroupBlockSchema() *schema.BlockSchema {
@@ -37,6 +38,20 @@ func deploymentGroupBlockSchema() *schema.BlockSchema {
 					Constraint: schema.List{
 						Elem: schema.Reference{OfScopeId: refscope.DeploymentAutoApproveScope},
 					},
+				},
+				"failure_tolerance": {
+					Description: lang.Markdown("The maximum number of failed deployments allowed in the group. This limits the number of concurrent applies in the group and halts automated rollout of the group once the tolerance is exceeded. Legal values are integers `>= 0`. Defaults to unlimited failures allowed."),
+					IsOptional:  true,
+					Constraint:  schema.LiteralType{Type: cty.Number},
+				},
+				"eager_plan": {
+					Description: lang.Markdown("Allow groups to opt-out of having their plans start immediately. This is a performance optimization for large groups."),
+					IsOptional:  true,
+					Constraint: schema.OneOf{
+						schema.LiteralValue{Value: cty.StringVal("on")},
+						schema.LiteralValue{Value: cty.StringVal("off")},
+					},
+					DefaultValue: schema.DefaultValue{Value: cty.StringVal("on")},
 				},
 			},
 		},

--- a/schema/versions_gen.go
+++ b/schema/versions_gen.go
@@ -7,11 +7,15 @@ import (
 
 var (
 	OldestAvailableVersion = version.Must(version.NewVersion("0.12.0"))
-	LatestAvailableVersion = version.Must(version.NewVersion("1.15.6"))
+	LatestAvailableVersion = version.Must(version.NewVersion("1.15.7"))
 
 	terraformVersions = version.Collection{
+		version.Must(version.NewVersion("1.16.0-alpha20260626")),
+		version.Must(version.NewVersion("1.16.0-alpha20260624")),
+		version.Must(version.NewVersion("1.16.0-alpha20260617")),
 		version.Must(version.NewVersion("1.16.0-alpha20260603")),
 		version.Must(version.NewVersion("1.16.0-alpha20260513")),
+		version.Must(version.NewVersion("1.15.7")),
 		version.Must(version.NewVersion("1.15.6")),
 		version.Must(version.NewVersion("1.15.5")),
 		version.Must(version.NewVersion("1.15.4")),


### PR DESCRIPTION
Added attribute failure_tolerance and eager_plan to deployment_group

## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
