### PR TITLE
Collect reference origins in uninstalled module blocks

### DIFF
--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -17,6 +17,41 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// schemaForUninstalledModuleBlock returns a permissive module block body schema for
+// declared modules whose inputs and outputs are not yet available locally (for example
+// remote modules before terraform init).
+//
+// The schema enables reference origin collection for expressions used as module input
+// values (such as var.* references) without requiring child module metadata. Input
+// name completion and navigation into the child module still require the module to
+// be installed.
+func schemaForUninstalledModuleBlock(module module.DeclaredModuleCall) *schema.BodySchema {
+	bodySchema := &schema.BodySchema{
+		AnyAttribute: &schema.AttributeSchema{
+			Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+		},
+	}
+
+	if module.LocalName == "" {
+		return bodySchema
+	}
+
+	addr := lang.Address{
+		lang.RootStep{Name: "module"},
+		lang.AttrStep{Name: module.LocalName},
+	}
+	bodySchema.TargetableAs = []*schema.Targetable{
+		{
+			Address:           addr,
+			ScopeId:           refscope.ModuleScope,
+			AsType:            cty.Object(map[string]cty.Type{}),
+			NestedTargetables: []*schema.Targetable{},
+		},
+	}
+
+	return bodySchema
+}
+
 func schemaForDependentRegistryModuleBlock(module module.DeclaredModuleCall, modMeta *registry.ModuleData) (*schema.BodySchema, error) {
 	attributes := make(map[string]*schema.AttributeSchema, 0)
 

--- a/schema/module_schema_reference_origins_test.go
+++ b/schema/module_schema_reference_origins_test.go
@@ -1,0 +1,132 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl-lang/decoder"
+	"github.com/hashicorp/hcl-lang/lang"
+	"github.com/hashicorp/hcl-lang/reference"
+	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform-schema/module"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type testDecoderPathReader struct {
+	paths map[string]*decoder.PathContext
+}
+
+func (r *testDecoderPathReader) Paths(ctx context.Context) []lang.Path {
+	paths := make([]lang.Path, 0, len(r.paths))
+	for path := range r.paths {
+		paths = append(paths, lang.Path{Path: path})
+	}
+	return paths
+}
+
+func (r *testDecoderPathReader) PathContext(path lang.Path) (*decoder.PathContext, error) {
+	if ctx, ok := r.paths[path.Path]; ok {
+		return ctx, nil
+	}
+	return nil, fmt.Errorf("path not found: %q", path.Path)
+}
+
+func TestUninstalledModuleBlock_collectsVarReferenceOrigins(t *testing.T) {
+	source := "git::https://github.com/example/module.git"
+	depSchema := schemaForUninstalledModuleBlock(module.DeclaredModuleCall{
+		LocalName: "app",
+	})
+
+	bodySchema := &schema.BodySchema{
+		Blocks: map[string]*schema.BlockSchema{
+			"module": {
+				Labels: []*schema.LabelSchema{{Name: "name"}},
+				Body: &schema.BodySchema{
+					Extensions: &schema.BodyExtensions{
+						Count:   true,
+						ForEach: true,
+					},
+					Attributes: map[string]*schema.AttributeSchema{
+						"source": {
+							Constraint: schema.LiteralType{Type: cty.String},
+							IsRequired: true,
+							IsDepKey:   true,
+						},
+					},
+				},
+				DependentBody: map[schema.SchemaKey]*schema.BodySchema{
+					schema.NewSchemaKey(schema.DependencyKeys{
+						Attributes: []schema.AttributeDependent{
+							{
+								Name: "source",
+								Expr: schema.ExpressionValue{
+									Static: cty.StringVal(source),
+								},
+							},
+						},
+					}): depSchema,
+				},
+			},
+		},
+	}
+
+	cfg := `module "app" {
+  source = "git::https://github.com/example/module.git"
+  name   = var.location
+}
+`
+	f, diags := hclsyntax.ParseConfig([]byte(cfg), "main.tf", hcl.InitialPos)
+	if len(diags) > 0 {
+		t.Fatal(diags)
+	}
+
+	dirPath := t.TempDir()
+	d := decoder.NewDecoder(&testDecoderPathReader{
+		paths: map[string]*decoder.PathContext{
+			dirPath: {
+				Schema: bodySchema,
+				Files: map[string]*hcl.File{
+					"main.tf": f,
+				},
+			},
+		},
+	})
+	d.SetContext(decoder.NewDecoderContext())
+
+	pathDecoder, err := d.Path(lang.Path{Path: dirPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origins, err := pathDecoder.CollectReferenceOrigins()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	expectedAddr := lang.Address{
+		lang.RootStep{Name: "var"},
+		lang.AttrStep{Name: "location"},
+	}
+	for _, origin := range origins {
+		localOrigin, ok := origin.(reference.LocalOrigin)
+		if !ok {
+			continue
+		}
+		if cmp.Equal(localOrigin.Addr, expectedAddr) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected var.location reference origin, got %#v", origins)
+	}
+}

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -563,3 +563,30 @@ func TestSchemaForDeclaredDependentModuleBlock_basic(t *testing.T) {
 		t.Fatalf("schema mismatch: %s", diff)
 	}
 }
+
+func TestSchemaForUninstalledModuleBlock(t *testing.T) {
+	depSchema := schemaForUninstalledModuleBlock(module.DeclaredModuleCall{
+		LocalName: "app_infra",
+	})
+
+	expected := &schema.BodySchema{
+		AnyAttribute: &schema.AttributeSchema{
+			Constraint: schema.AnyExpression{OfType: cty.DynamicPseudoType},
+		},
+		TargetableAs: []*schema.Targetable{
+			{
+				Address: lang.Address{
+					lang.RootStep{Name: "module"},
+					lang.AttrStep{Name: "app_infra"},
+				},
+				ScopeId:           refscope.ModuleScope,
+				AsType:            cty.Object(map[string]cty.Type{}),
+				NestedTargetables: []*schema.Targetable{},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(expected, depSchema, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("schema mismatch: %s", diff)
+	}
+}

--- a/schema/schema_merge.go
+++ b/schema/schema_merge.go
@@ -315,65 +315,61 @@ func (m *SchemaMerger) SchemaForModule(meta *tfmod.Meta) (*schema.BodySchema, er
 			},
 		}
 
-		switch sourceAddr := module.SourceAddr.(type) {
-		case tfaddr.Module:
-			// 1. See if we have a local installation of the module available
-			installedDir, ok := m.stateReader.InstalledModulePath(meta.Path, sourceAddr.String())
-			if ok {
-				path := filepath.Join(meta.Path, installedDir)
+		mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = m.resolveModuleDependentBody(meta.Path, module)
+	}
 
-				modMeta, err := m.stateReader.LocalModuleMeta(path)
+	return mergedSchema, nil
+}
+
+func (m *SchemaMerger) resolveModuleDependentBody(rootPath string, module tfmod.DeclaredModuleCall) *schema.BodySchema {
+	switch sourceAddr := module.SourceAddr.(type) {
+	case tfaddr.Module:
+		if installedDir, ok := m.stateReader.InstalledModulePath(rootPath, sourceAddr.String()); ok {
+			path := filepath.Join(rootPath, installedDir)
+
+			modMeta, err := m.stateReader.LocalModuleMeta(path)
+			if err == nil {
+				depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 				if err == nil {
-					depSchema, err := schemaForDependentModuleBlock(module, modMeta)
-					if err == nil {
-						mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
-					}
-
-					// We continue here, so we don't end up overwriting the schema with one from the registry
-					continue
+					return depSchema
 				}
 			}
+		}
 
-			// 2. See if we have fetched the module schema from the registry
-			modMeta, err := m.stateReader.RegistryModuleMeta(sourceAddr, module.Version)
-			if err != nil {
-				continue
-			}
-
+		modMeta, err := m.stateReader.RegistryModuleMeta(sourceAddr, module.Version)
+		if err == nil {
 			depSchema, err := schemaForDependentRegistryModuleBlock(module, modMeta)
 			if err == nil {
-				mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
+				return depSchema
 			}
+		}
 
-		case tfmod.RemoteSourceAddr:
-			installedDir, ok := m.stateReader.InstalledModulePath(meta.Path, sourceAddr.String())
-			if !ok {
-				continue
-			}
-			path := filepath.Join(meta.Path, installedDir)
+	case tfmod.RemoteSourceAddr:
+		if installedDir, ok := m.stateReader.InstalledModulePath(rootPath, sourceAddr.String()); ok {
+			path := filepath.Join(rootPath, installedDir)
 
 			modMeta, err := m.stateReader.LocalModuleMeta(path)
 			if err == nil {
 				depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 				if err == nil {
-					mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
+					return depSchema
 				}
 			}
+		}
 
-		case tfmod.LocalSourceAddr:
-			path := filepath.Join(meta.Path, sourceAddr.String())
+	case tfmod.LocalSourceAddr:
+		path := filepath.Join(rootPath, sourceAddr.String())
 
-			modMeta, err := m.stateReader.LocalModuleMeta(path)
+		modMeta, err := m.stateReader.LocalModuleMeta(path)
+		if err == nil {
+			depSchema, err := schemaForDependentModuleBlock(module, modMeta)
 			if err == nil {
-				depSchema, err := schemaForDependentModuleBlock(module, modMeta)
-				if err == nil {
-					mergedSchema.Blocks["module"].DependentBody[schema.NewSchemaKey(depKeys)] = depSchema
-				}
+				return depSchema
 			}
 		}
 	}
 
-	return mergedSchema, nil
+	return schemaForUninstalledModuleBlock(module)
 }
 
 // TypeBelongsToProvider returns true if the given type

--- a/schema/schema_merge_module_test.go
+++ b/schema/schema_merge_module_test.go
@@ -1,0 +1,79 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl-lang/schema"
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+	"github.com/hashicorp/terraform-schema/module"
+	"github.com/hashicorp/terraform-schema/registry"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+)
+
+type uninstalledRemoteModuleReader struct{}
+
+func (r *uninstalledRemoteModuleReader) ProviderSchema(modPath string, addr tfaddr.Provider, vc version.Constraints) (*ProviderSchema, error) {
+	return nil, nil
+}
+
+func (r *uninstalledRemoteModuleReader) RegistryModuleMeta(addr tfaddr.Module, cons version.Constraints) (*registry.ModuleData, error) {
+	return nil, fmt.Errorf("module not available")
+}
+
+func (r *uninstalledRemoteModuleReader) DeclaredModuleCalls(modPath string) (map[string]module.DeclaredModuleCall, error) {
+	rawSource := "git::https://github.com/example/module.git"
+	return map[string]module.DeclaredModuleCall{
+		"app": {
+			LocalName:     "app",
+			RawSourceAddr: rawSource,
+			SourceAddr:    module.RemoteSourceAddr("git::https://github.com/example/module.git"),
+		},
+	}, nil
+}
+
+func (r *uninstalledRemoteModuleReader) InstalledModulePath(rootPath string, normalizedSource string) (string, bool) {
+	return "", false
+}
+
+func (r *uninstalledRemoteModuleReader) LocalModuleMeta(modPath string) (*module.Meta, error) {
+	return nil, fmt.Errorf("module not available")
+}
+
+func TestSchemaMerger_resolveModuleDependentBody_uninstalledRemoteModule(t *testing.T) {
+	sm := NewSchemaMerger(testCoreSchema())
+	sm.SetStateReader(&uninstalledRemoteModuleReader{})
+	sm.SetTerraformVersion(v0_15_0)
+
+	meta := &module.Meta{
+		Path:      "/test",
+		Filenames: []string{"main.tf"},
+	}
+	mergedSchema, err := sm.SchemaForModule(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	moduleSchema := mergedSchema.Blocks["module"]
+	if len(moduleSchema.DependentBody) != 1 {
+		t.Fatalf("expected 1 dependent body schema, got %d", len(moduleSchema.DependentBody))
+	}
+
+	var depSchema *schema.BodySchema
+	for _, bodySchema := range moduleSchema.DependentBody {
+		depSchema = bodySchema
+		break
+	}
+
+	expected := schemaForUninstalledModuleBlock(module.DeclaredModuleCall{
+		LocalName: "app",
+	})
+	if diff := cmp.Diff(expected, depSchema, ctydebug.CmpOptions); diff != "" {
+		t.Fatalf("schema mismatch: %s", diff)
+	}
+}


### PR DESCRIPTION
## Summary

- Add a permissive dependent body schema fallback for declared modules whose inputs are not yet available locally (e.g. remote modules before `terraform init`)
- Refactor module dependent-body resolution into `resolveModuleDependentBody`
- Add tests for schema generation, merger fallback, and end-to-end reference origin collection

## Motivation

When a root module declares a remote `module` block but the child module has not been installed locally (no `terraform init`), the language server currently applies no dependent body schema for that module block. As a result, expressions used as module arguments — including references to locally declared symbols such as `var.*` — are not decoded and cannot be navigated via go-to-definition.

This is unnecessarily strict: the current module's schema is known, and variable definitions live in the current module. Resolving `var.*` references used as module arguments should not require child module metadata.

This change provides a fallback `AnyAttribute` dependent body schema for uninstalled modules. This enables reference origin collection for module argument expressions. Module input name completion and navigation into the child module still require the module to be installed.

**Note:** This change depends on [hashicorp/hcl-lang#490](https://github.com/hashicorp/hcl-lang/pull/490), which propagates `AnyAttribute` when merging dependent body schemas. Without that `hcl-lang` change, the permissive schema defined here is dropped during merge and reference origins are still not collected.

## Behavior

| Feature | Before init | After init |
|---|---|---|
| Go-to-definition on `var.*` in module args | ❌ | ✅ |
| Go-to-definition on `local.*` in module args | ❌ | ✅ |
| Module input name completion | ❌ | ✅ |
| Navigation into child module | ❌ | ✅ |

## Test plan

- [x] `go test ./schema/ -run TestSchemaForUninstalledModuleBlock`
- [x] `go test ./schema/ -run TestSchemaMerger_resolveModuleDependentBody_uninstalledRemoteModule`
- [x] `go test ./schema/ -run TestUninstalledModuleBlock_collectsVarReferenceOrigins`
- [x] Manually verified with a patched `terraform-ls` build: go-to-definition on `var.*` inside a remote `module` block works without `terraform init`, while the stock bundled language server does not

Made with [Cursor](https://cursor.com)